### PR TITLE
fix: various UX improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2595,6 +2595,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "human_bytes"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
+
+[[package]]
 name = "humantime"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5403,7 +5409,7 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tari-cli"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "cargo-generate",
@@ -5413,6 +5419,7 @@ dependencies = [
  "dialoguer",
  "dirs-next 2.0.0",
  "git2",
+ "human_bytes",
  "serde",
  "spinners",
  "tari_deploy",
@@ -5428,7 +5435,7 @@ dependencies = [
 [[package]]
 name = "tari_bor"
 version = "0.10.4"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#63a71514537d84bb6071826bc1b440081469ddfc"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#05228d7478a1ce4d1e6e248a858f9f90c7c06701"
 dependencies = [
  "ciborium",
  "ciborium-io",
@@ -5527,7 +5534,7 @@ dependencies = [
 [[package]]
 name = "tari_consensus_types"
 version = "0.10.4"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#63a71514537d84bb6071826bc1b440081469ddfc"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#05228d7478a1ce4d1e6e248a858f9f90c7c06701"
 dependencies = [
  "borsh",
  "serde",
@@ -5565,12 +5572,13 @@ dependencies = [
 
 [[package]]
 name = "tari_deploy"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "hickory-proto",
  "serde",
  "tari_engine",
  "tari_engine_types",
+ "tari_ootle_common_types",
  "tari_template_lib",
  "tari_wallet_daemon_client",
  "thiserror 2.0.12",
@@ -5582,7 +5590,7 @@ dependencies = [
 [[package]]
 name = "tari_engine"
 version = "0.10.4"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#63a71514537d84bb6071826bc1b440081469ddfc"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#05228d7478a1ce4d1e6e248a858f9f90c7c06701"
 dependencies = [
  "anyhow",
  "blake2",
@@ -5612,7 +5620,7 @@ dependencies = [
 [[package]]
 name = "tari_engine_types"
 version = "0.10.4"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#63a71514537d84bb6071826bc1b440081469ddfc"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#05228d7478a1ce4d1e6e248a858f9f90c7c06701"
 dependencies = [
  "base64 0.21.7",
  "blake2",
@@ -5725,7 +5733,7 @@ dependencies = [
 [[package]]
 name = "tari_ootle_common_types"
 version = "0.10.4"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#63a71514537d84bb6071826bc1b440081469ddfc"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#05228d7478a1ce4d1e6e248a858f9f90c7c06701"
 dependencies = [
  "borsh",
  "ethnum",
@@ -5750,7 +5758,7 @@ dependencies = [
 [[package]]
 name = "tari_ootle_wallet_crypto"
 version = "0.10.4"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#63a71514537d84bb6071826bc1b440081469ddfc"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#05228d7478a1ce4d1e6e248a858f9f90c7c06701"
 dependencies = [
  "blake2",
  "chacha20poly1305",
@@ -5768,7 +5776,7 @@ dependencies = [
 [[package]]
 name = "tari_ootle_wallet_sdk"
 version = "0.10.4"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#63a71514537d84bb6071826bc1b440081469ddfc"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#05228d7478a1ce4d1e6e248a858f9f90c7c06701"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5840,7 +5848,7 @@ dependencies = [
 [[package]]
 name = "tari_template_abi"
 version = "0.10.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#63a71514537d84bb6071826bc1b440081469ddfc"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#05228d7478a1ce4d1e6e248a858f9f90c7c06701"
 dependencies = [
  "serde",
  "tari_bor",
@@ -5849,7 +5857,7 @@ dependencies = [
 [[package]]
 name = "tari_template_builtin"
 version = "0.10.4"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#63a71514537d84bb6071826bc1b440081469ddfc"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#05228d7478a1ce4d1e6e248a858f9f90c7c06701"
 dependencies = [
  "serde",
  "tari_bor",
@@ -5859,7 +5867,7 @@ dependencies = [
 [[package]]
 name = "tari_template_lib"
 version = "0.11.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#63a71514537d84bb6071826bc1b440081469ddfc"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#05228d7478a1ce4d1e6e248a858f9f90c7c06701"
 dependencies = [
  "borsh",
  "newtype-ops",
@@ -5873,7 +5881,7 @@ dependencies = [
 [[package]]
 name = "tari_template_lib_types"
 version = "0.10.4"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#63a71514537d84bb6071826bc1b440081469ddfc"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#05228d7478a1ce4d1e6e248a858f9f90c7c06701"
 dependencies = [
  "borsh",
  "serde",
@@ -5883,7 +5891,7 @@ dependencies = [
 [[package]]
 name = "tari_template_macros"
 version = "0.10.0"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#63a71514537d84bb6071826bc1b440081469ddfc"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#05228d7478a1ce4d1e6e248a858f9f90c7c06701"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5895,7 +5903,7 @@ dependencies = [
 [[package]]
 name = "tari_transaction"
 version = "0.10.4"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#63a71514537d84bb6071826bc1b440081469ddfc"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#05228d7478a1ce4d1e6e248a858f9f90c7c06701"
 dependencies = [
  "borsh",
  "indexmap 2.9.0",
@@ -5931,7 +5939,7 @@ dependencies = [
 [[package]]
 name = "tari_wallet_daemon_client"
 version = "0.10.4"
-source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#63a71514537d84bb6071826bc1b440081469ddfc"
+source = "git+https://github.com/tari-project/tari-ootle.git?branch=development#05228d7478a1ce4d1e6e248a858f9f90c7c06701"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/tari_deploy", "crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-cli"
@@ -20,4 +20,5 @@ url = { version = "2.5.3", features = ["default", "serde"] }
 tari_wallet_daemon_client = { git = "https://github.com/tari-project/tari-ootle.git", branch = "development" }
 tari_engine = { git = "https://github.com/tari-project/tari-ootle.git", branch = "development" }
 tari_engine_types = { git = "https://github.com/tari-project/tari-ootle.git", branch = "development" }
+tari_ootle_common_types = { git = "https://github.com/tari-project/tari-ootle.git", branch = "development" }
 tari_template_lib = { git = "https://github.com/tari-project/tari-ootle.git", branch = "development" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -27,6 +27,7 @@ spinners = "4.1.1"
 convert_case = "0.7.1"
 dialoguer = { version = "0.11.0", features = ["default", "fuzzy-select"] }
 cargo_toml = "0.21.0"
+human_bytes = "0.4.3"
 url = { workspace = true }
 
 [dev-dependencies]

--- a/crates/cli/src/cli/commands/deploy.rs
+++ b/crates/cli/src/cli/commands/deploy.rs
@@ -1,19 +1,21 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use crate::cli::config::Config;
 use crate::cli::util;
 use crate::{loading, project};
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use cargo_toml::Manifest;
 use clap::Parser;
 use dialoguer::Confirm;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::str::FromStr;
-use tari_deploy::deployer::{Template, TemplateDeployer, TOKEN_SYMBOL};
+use tari_deploy::deployer::{CheckBalanceResult, Template, TemplateDeployer, TOKEN_SYMBOL};
 use tari_wallet_daemon_client::ComponentAddressOrName;
 use tokio::fs;
 use tokio::process::Command;
+
+const MAX_WASM_SIZE: usize = 5 * 1000 * 1000; // 5 MB
 
 #[derive(Clone, Parser, Debug)]
 pub struct DeployArgs {
@@ -23,7 +25,7 @@ pub struct DeployArgs {
 
     /// Account to be used for deployment fees.
     #[arg(short = 'a', long)]
-    pub account: String,
+    pub account: Option<ComponentAddressOrName>,
 
     /// (Optional) Custom network name.
     /// Custom network name set in project config.
@@ -44,62 +46,106 @@ pub struct DeployArgs {
     pub max_fee: Option<u64>,
 
     /// Project folder where we have the project configuration file (tari.config.toml).
-    #[arg(long, value_name = "PATH", default_value = crate::cli::arguments::default_target_dir().into_os_string()
+    #[arg(long, value_name = "PATH", default_value = crate::cli::command::default_target_dir().into_os_string()
     )]
     pub project_folder: PathBuf,
 }
 
-pub async fn handle(args: &DeployArgs) -> anyhow::Result<()> {
+pub async fn handle(config: Config, args: &DeployArgs) -> anyhow::Result<()> {
     // load network config from project config file
     let project_config = load_project_config(&args.project_folder).await?;
 
     // lookup project name and dir
-    let mut project_dir = None;
-    let mut project_name = String::new();
+    let mut crate_dir = None;
+    let mut crate_name = String::new();
     let workspace_cargo_toml = Manifest::from_path(args.project_folder.join("Cargo.toml"))?;
-    let projects = workspace_cargo_toml
+    let crates = workspace_cargo_toml
         .workspace
         .ok_or(anyhow!("Project is not a Cargo workspace project!"))?
         .members;
-    for project in projects {
+    for project in crates {
         let cargo_toml =
             Manifest::from_path(args.project_folder.join(project.clone()).join("Cargo.toml"))?;
-        let curr_project_name = cargo_toml
+        let curr_crate_name = cargo_toml
             .package
             .ok_or(anyhow!("No package details set!"))?
             .name;
-        if curr_project_name.to_lowercase() == args.template.to_lowercase() {
-            project_dir = Some(args.project_folder.join(project));
-            project_name = curr_project_name;
+        if curr_crate_name.eq_ignore_ascii_case(&args.template) {
+            crate_dir = Some(args.project_folder.join(project));
+            crate_name = curr_crate_name;
         }
     }
-    if project_dir.is_none() {
+    let Some(crate_dir) = crate_dir else {
         return Err(anyhow!("Project \"{}\" not found!", args.template));
-    }
-    let project_dir = project_dir.unwrap();
+    };
 
     // build
     let template_bin = loading!(
-        format!("Building WASM template project **{}**", project_name),
-        build_project(&project_dir, project_name.clone()).await
+        format!("Building WASM template project **{}**", crate_name),
+        build_project(&crate_dir, &crate_name).await
     )?;
 
     // template deployer
     let deployer = TemplateDeployer::new(project_config.network().clone());
-    let account = ComponentAddressOrName::from_str(args.account.as_str())?;
+    let info = deployer.get_wallet_info().await.with_context(|| {
+        anyhow!(
+            "Failed to connect to the wallet at {}",
+            project_config.network().wallet_daemon_jrpc_address(),
+        )
+    })?;
+
+    println!(
+        "🔗 Connected to wallet version {} (network: {})",
+        info.version, info.network
+    );
+
+    let account = args
+        .account
+        .as_ref()
+        .cloned()
+        .or_else(|| {
+            project_config
+                .parsed_default_account()
+                .expect("Malformed default account")
+        })
+        .or(config.default_account);
+    let account = match account {
+        Some(account) => {
+            println!("🔍 Using account: {account}");
+            account
+        }
+        None => {
+            let account = deployer.get_default_account().await?;
+            let Some(account) = account else {
+                return Err(anyhow!("No account found! Please create an account first."));
+            };
+            println!("❓ No Account specified. Using default account: {account}");
+            account
+        }
+    };
     let template = Template::Path { path: template_bin };
 
-    // check balance
-    deployer
+    // check balance and get max fee
+    let CheckBalanceResult {
+        max_fee,
+        binary_size,
+    } = deployer
         .check_balance_to_deploy(&account, &template)
         .await?;
 
-    let max_fee = deployer.publish_fee(&account, &template).await?;
+    if binary_size > MAX_WASM_SIZE {
+        println!(
+            "⚠️ WASM binary size exceeded: {}",
+            util::human_bytes(binary_size)
+        );
+    } else {
+        println!("✅ WASM size: {}", util::human_bytes(binary_size));
+    }
 
     if !args.yes {
         let confirmation = Confirm::new()
             .with_prompt(format!(
-                "❓Deploying this template costs {max_fee} {TOKEN_SYMBOL} (estimated), are you sure to continue?",
+                "⚠️ Deploying this template costs {max_fee} {TOKEN_SYMBOL} (estimated), are you sure to continue?",
             ))
             .interact()?;
         if !confirmation {
@@ -109,7 +155,7 @@ pub async fn handle(args: &DeployArgs) -> anyhow::Result<()> {
 
     // deploy
     let template_address = loading!(
-        format!("Deploying project **{}**...", project_name),
+        format!("Deploying template **{crate_name}**. This may take while..."),
         deployer.deploy(&account, template, max_fee, None).await
     )?;
 
@@ -118,7 +164,7 @@ pub async fn handle(args: &DeployArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn build_project(dir: &Path, name: String) -> anyhow::Result<PathBuf> {
+async fn build_project(dir: &Path, name: &str) -> anyhow::Result<PathBuf> {
     let mut cmd = Command::new("cargo");
     cmd.arg("build")
         .arg("--target=wasm32-unknown-unknown")
@@ -154,7 +200,7 @@ async fn build_project(dir: &Path, name: String) -> anyhow::Result<PathBuf> {
     Ok(output_bin)
 }
 
-async fn load_project_config(project_folder: &Path) -> anyhow::Result<project::Config> {
+async fn load_project_config(project_folder: &Path) -> anyhow::Result<project::ProjectConfig> {
     let config_file = project_folder.join(project::CONFIG_FILE_NAME);
     Ok(toml::from_str(
         fs::read_to_string(&config_file)

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -3,4 +3,4 @@
 
 pub mod create;
 pub mod deploy;
-pub mod new;
+pub mod generate;

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-pub mod arguments;
+pub mod command;
 pub mod commands;
 pub mod config;
 pub mod macros;

--- a/crates/cli/src/cli/util.rs
+++ b/crates/cli/src/cli/util.rs
@@ -22,12 +22,16 @@ pub async fn path_metadata(path: &PathBuf) -> io::Result<Metadata> {
     fs::metadata(path).await
 }
 
-pub fn cli_select<T: ToString + Clone>(prompt: &str, items: &[T]) -> anyhow::Result<T> {
+pub fn cli_select<'a, T: ToString>(prompt: &str, items: &'a [T]) -> anyhow::Result<&'a T> {
     let selection = FuzzySelect::new()
         .with_prompt(prompt)
         .highlight_matches(true)
         .items(items)
         .interact()?;
 
-    Ok(items[selection].clone())
+    Ok(&items[selection])
+}
+
+pub fn human_bytes(n: usize) -> String {
+    human_bytes::human_bytes(n as f64)
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4,7 +4,7 @@
 use clap::Parser;
 use std::process::exit;
 
-use crate::cli::arguments::Cli;
+use crate::cli::command::Cli;
 
 mod cli;
 mod git;

--- a/crates/cli/src/project/config.rs
+++ b/crates/cli/src/project/config.rs
@@ -3,6 +3,7 @@
 
 use serde::{Deserialize, Serialize};
 use tari_deploy::NetworkConfig;
+use tari_wallet_daemon_client::ComponentAddressOrName;
 use thiserror::Error;
 use url::Url;
 
@@ -14,20 +15,31 @@ pub enum Error {
 
 /// Project configuration.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Config {
+pub struct ProjectConfig {
     network: NetworkConfig,
+    default_account: Option<String>,
 }
 
-impl Config {
+impl ProjectConfig {
     pub fn network(&self) -> &NetworkConfig {
         &self.network
     }
+
+    pub fn parsed_default_account(&self) -> anyhow::Result<Option<ComponentAddressOrName>> {
+        let acc = self
+            .default_account
+            .as_ref()
+            .map(|s| s.parse())
+            .transpose()?;
+        Ok(acc)
+    }
 }
 
-impl Default for Config {
+impl Default for ProjectConfig {
     fn default() -> Self {
         Self {
             network: NetworkConfig::new(Url::parse("http://127.0.0.1:9000").unwrap()),
+            default_account: None,
         }
     }
 }

--- a/crates/tari_deploy/Cargo.toml
+++ b/crates/tari_deploy/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 
 [dependencies]
 tari_wallet_daemon_client = { workspace = true }
+tari_ootle_common_types = { workspace = true }
 tari_engine = { workspace = true }
 tari_engine_types = { workspace = true }
 tari_template_lib = { workspace = true }

--- a/crates/tari_deploy/src/error.rs
+++ b/crates/tari_deploy/src/error.rs
@@ -3,6 +3,7 @@
 
 use std::io;
 use tari_engine::template::TemplateLoaderError;
+use tari_template_lib::models::Amount;
 use tari_template_lib::types::HashParseError;
 use tari_wallet_daemon_client::error::WalletDaemonClientError;
 use thiserror::Error;
@@ -20,8 +21,10 @@ pub enum Error {
     IO(#[from] io::Error),
     #[error("Invalid hash error: {0}")]
     InvalidHash(#[from] HashParseError),
-    #[error("Insufficient balance in Tari L2 wallet! Current balance: {0}, Estimated Fee: {1}")]
-    InsufficientBalance(u64, u64),
+    #[error(
+        "Insufficient balance in Tari L2 wallet! Current balance: {current}, Estimated Fee: {fee}"
+    )]
+    InsufficientBalance { current: Amount, fee: Amount },
     #[error("Waiting for transaction timed out! Transaction ID: {0}")]
     WaitForTransactionTimeout(String),
     #[error("Invalid transaction: {0}!\n{1}")]
@@ -30,4 +33,6 @@ pub enum Error {
     MissingTransactionResult(String),
     #[error("Missing published template in substates!")]
     MissingPublishedTemplate,
+    #[error("Invalid response: {0}")]
+    InvalidResponse(String),
 }


### PR DESCRIPTION
Description
---
- `tari new` becomes `tari generate`
- `tari new/create` creates a new project
- output WASM size
- allow a default account to be specified in the global or project level tari.config.toml
- perf: don't submit the dry run multiple times

Motivation and Context
---
The difference between `tari new` and `tari create` were unclear. `tari generate` is clearer in that it generates another template and does nothing else.

How Has This Been Tested?
---
Tested from generation to deployment

What process can a PR reviewer use to test or verify this change?
---

Breaking Changes
---

- [x] None
- [ ] Requires CLI data directory to be deleted
- [ ] Other - Please specify