### PR TITLE
feat(ci): create github release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            name: linux-x86_64
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            name: windows-x86_64
+            archive: zip
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            name: macos-x86_64
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-14
+            name: macos-aarch64
+            archive: tar.gz
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Create archive (Unix)
+        if: matrix.archive == 'tar.gz'
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/tari dist/
+          cd dist
+          tar -czf ../tari-${{ matrix.name }}.tar.gz tari
+
+      - name: Create archive (Windows)
+        if: matrix.archive == 'zip'
+        run: |
+          mkdir dist
+          cp target/${{ matrix.target }}/release/tari.exe dist/
+          cd dist
+          7z a ../tari-${{ matrix.name }}.zip tari.exe
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tari-${{ matrix.name }}
+          path: tari-${{ matrix.name }}.${{ matrix.archive }}
+
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create release
+        run: |
+          # Extract tag name from ref
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          # Create release with GitHub CLI
+          gh release create "$TAG_NAME" \
+            artifacts/*/tari-* \
+            --generate-notes \
+            --title "$TAG_NAME"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automating the release process. The workflow builds release binaries for multiple platforms, archives them, and creates a GitHub release upon tagging.

### New GitHub Actions workflow for releases:

* Added `.github/workflows/release.yml` to define a `Release` workflow triggered by `v*` tags or manual dispatch. The workflow includes two jobs: `build` and `release`.

#### Build job:
* Configured a build matrix to target multiple platforms (`linux-x86_64`, `windows-x86_64`, `macos-x86_64`, `macos-aarch64`) with appropriate OS and archive formats (`tar.gz` or `zip`).
* Steps include checking out code, installing Rust, caching dependencies, building release binaries, creating platform-specific archives, and uploading artifacts.

#### Release job:
* Downloads all artifacts from the `build` job and creates a GitHub release using the GitHub CLI. The release includes all built artifacts and auto-generated release notes.