### PR TITLE
fix(ci): install os deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            name: linux-x86_64
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            name: windows-x86_64
+            archive: zip
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            name: macos-x86_64
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-14
+            name: macos-aarch64
+            archive: tar.gz
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Create archive (Unix)
+        if: matrix.archive == 'tar.gz'
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/tari dist/
+          cd dist
+          tar -czf ../tari-${{ matrix.name }}.tar.gz tari
+
+      - name: Create archive (Windows)
+        if: matrix.archive == 'zip'
+        run: |
+          mkdir dist
+          cp target/${{ matrix.target }}/release/tari.exe dist/
+          cd dist
+          7z a ../tari-${{ matrix.name }}.zip tari.exe
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tari-${{ matrix.name }}
+          path: tari-${{ matrix.name }}.${{ matrix.archive }}
+
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create release
+        run: |
+          # Extract tag name from ref
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          # Create release with GitHub CLI
+          gh release create "$TAG_NAME" \
+            artifacts/*/tari-* \
+            --generate-notes \
+            --title "$TAG_NAME"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,6 @@ jobs:
             os: windows-latest
             name: windows-x86_64
             archive: zip
-          - target: x86_64-apple-darwin
-            os: macos-latest
-            name: macos-x86_64
-            archive: tar.gz
           - target: aarch64-apple-darwin
             os: macos-14
             name: macos-aarch64
@@ -54,7 +50,11 @@ jobs:
 
       - name: Install dependencies (Windows)
         if: matrix.os == 'windows-latest'
-        run: vcpkg install openssl:x64-windows-static
+        shell: bash
+        run: |
+          vcpkg install openssl:x64-windows-static
+          echo "VCPKG_ROOT=C:\vcpkg" >> $GITHUB_ENV
+          echo "OPENSSL_DIR=C:\vcpkg\packages\openssl_x64-windows-static" >> $GITHUB_ENV
 
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,18 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
 
+      - name: Install dependencies (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt install libdbus-1-dev pkg-config
+
+      - name: Install dependencies (macOS)
+        if: startsWith(matrix.os, 'macos')
+        run: brew install pkg-config openssl
+
+      - name: Install dependencies (Windows)
+        if: matrix.os == 'windows-latest'
+        run: vcpkg install openssl:x64-windows-static
+
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "stable"
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for releases by adding support for pull requests and ensuring platform-specific dependencies are installed during the build process.

### Workflow updates:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R7): Added `pull_request` as a trigger to the workflow, enabling it to run on pull request events.

### Dependency installation:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R47-R58): Added steps to install platform-specific dependencies for Ubuntu, macOS, and Windows in the build job. This ensures all required libraries are available before building the release binary.