### PR TITLE
fix: release url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Get your first Tari smart contract deployed in under 5 minutes:
 cargo install tari-cli --git https://github.com/tari-project/tari-cli --force
 
 # Or download from releases
-curl -L https://github.com/tari-project/tari-cli/releases/latest/download/tari-cli-linux.tar.gz | tar xz
+curl -L https://github.com/tari-project/tari-cli/releases/download/latest/tari-linux-x86_64.tar.gz | tar xz
 ```
 
 ### 2. Create Your First Project


### PR DESCRIPTION
fixed the release url in README.md

Description
Changed the release download url

Motivation and Context
Trying to build tari-cli and wanted to fix this.

How Has This Been Tested?
Tested manually by checking the url

What process can a PR reviewer use to test or verify this change?
Can use wget 

Breaking Changes
no

- [x] No
- [ ] Yes - Please specify