### PR TITLE
make alias for deploy

### DIFF
--- a/crates/cli/src/cli/command.rs
+++ b/crates/cli/src/cli/command.rs
@@ -135,6 +135,7 @@ pub enum Command {
         args: AddArgs,
     },
     /// Deploying Tari template to a network
+    #[clap(alias = "publish")]
     Deploy {
         #[clap(flatten)]
         args: DeployArgs,


### PR DESCRIPTION
Description
---
"publish" alias for deploy

Motivation and Context
---
If a user finds `tari publish` more memorable, it'll work
