### PR TITLE
docs: update README and reference docs for v0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,138 +1,120 @@
-# 🚀 Tari Ootle CLI
+# Tari Ootle CLI
 
-> **The complete toolkit for developing Tari smart contracts**
-
-[![GitHub Release](https://img.shields.io/github/v/release/tari-project/tari-cli)](https://github.com/tari-project/tari-cli/releases)
 [![CI Build Status](https://img.shields.io/github/actions/workflow/status/tari-project/tari-cli/pr-check.yml)](https://github.com/tari-project/tari-cli/actions/workflows/pr-check.yml)
 [![Crates.io](https://img.shields.io/crates/v/tari-ootle-cli)](https://crates.io/crates/tari-ootle-cli)
 [![docs.rs](https://img.shields.io/docsrs/tari-ootle-cli)](https://docs.rs/tari-ootle-cli)
-[![Documentation](https://img.shields.io/badge/docs-documentation-blue)](https://tari-project.github.io/tari-cli/)
+[![Docs](https://img.shields.io/badge/docs-tari--cli-blue)](https://tari-project.github.io/tari-cli/)
 
-The **Tari CLI** smart contract development tool for the Tari Layer-2 blockchain.
+The **Tari CLI** is the development tool for building and publishing smart contract templates on the [Tari Ootle](https://www.tari.com/) Layer-2 network.
 
-This CLI provides a streamlined workflow for building, testing, and publishing smart contracts on the Tari network. 
-With a focus on simplicity and developer experience, the Tari CLI abstracts away complex blockchain interactions, 
-allowing you to focus on writing your smart contract logic.
+## Quick Start
 
-## ✨ What You Can Build
-
-- **NFT Collections**: Create unique digital assets with custom metadata
-- **Token Systems**: Build fungible tokens with advanced features  
-- **DeFi Protocols**: Develop decentralized finance applications
-- **Custom Templates**: Design reusable smart contract patterns
-
-## 🚀 Quick Start
-
-Get your first Tari smart contract published in under 5 minutes:
-
-### 1. Install Tari CLI
+### Install
 
 ```bash
-# Using Cargo
-cargo install tari-cli 
-
-# Or download from releases
-curl -L https://github.com/tari-project/tari-cli/releases/download/latest/tari-linux-x86_64.tar.gz | tar xz
+cargo install tari-ootle-cli
 ```
 
-### 2. Create Your First Project
+Requires the WASM target:
 
-<!-- SOURCE: Actual CLI output from README.md:49-57 -->
 ```bash
-tari create my-first-contract
-
-# ✅ Init configuration and directories
-# ✅ Refresh project templates repository  
-# ✅ Refresh wasm templates repository
-# ✅ Collecting available project templates
-# 🔎 Select project template: Basic - The basic project template to get started
-# ✅ Generate new project
+rustup target add wasm32-unknown-unknown
 ```
 
-### 3. Add a Smart Contract
+### Create a template
 
-<!-- SOURCE: Actual CLI output from README.md:67-77 -->
 ```bash
-cd my-first-contract
-tari new MyToken
-
-# ✅ Init configuration and directories
-# ✅ Collecting available WASM templates  
-# 🔎 Select WASM template: NFT - A simple NFT template to create your own
-# ✅ Generate new project
-# ✅ Update Cargo.toml
+tari create my-token
 ```
 
-### 4. Publish to Network
+You'll be prompted to pick a starter template. This scaffolds a crate with `build.rs` and metadata configuration ready to go.
 
-<!-- SOURCE: Actual CLI output from README.md:89-97 -->
+### Build
+
 ```bash
-tari publish --account myaccount MyToken
-
-# ✅ Building WASM template project "MyToken"
-# ❓ Publishing this template costs 256875 XTR (estimated), are you sure to continue? yes
-# ✅ Publishing template. This may take a while...
-# ⭐ Your new template's address: f807989828e70a18050e5785f30a7bd01475797d76d6b4700af175b859c32774
+cd my-token
+tari build
+# ✅ WASM binary: target/.../my_token.wasm (42.3 KB)
+# 📄 Metadata:    target/.../template_metadata.cbor
 ```
 
-🎉 **Congratulations!** Your smart contract is live on Tari.
+### Inspect metadata
 
-## 📚 Documentation
+```bash
+tari metadata inspect
 
-### 🎯 Essential Guides
-- **[Getting Started](docs/01-getting-started/installation.md)** - Complete setup and first project
-- **[Template Development](docs/02-guides/template-development.md)** - Creating custom smart contracts
-- **[Configuration Guide](docs/02-guides/project-configuration.md)** - Project and network setup
-- **[Publishing Guide](docs/02-guides/deployment.md)** - From build to blockchain
+#   Name:           my-token
+#   Version:        0.1.0
+#   Tags:           token, defi
+#   Category:       token
+#   Logo URL:       https://example.com/logo.png
+#   Metadata hash:  ...
+```
 
-### 📖 Reference
-- **[CLI Commands](docs/03-reference/cli-commands.md)** - Complete command reference
-- **[Configuration Schema](docs/03-reference/configuration-schema.md)** - All configuration options
-- **[API Patterns](docs/03-reference/api-patterns.md)** - Implementation patterns from real code
+### Publish to network
 
-### 🔧 Help & Troubleshooting  
-- **[Common Issues](docs/04-troubleshooting/common-issues.md)** - Solutions to frequent problems
-- **[Advanced Debugging](docs/04-troubleshooting/debugging.md)** - Deep troubleshooting techniques
-- **[FAQ](docs/04-troubleshooting/faq.md)** - Frequently asked questions
+```bash
+tari publish -a myaccount
 
-### 🤝 Contributing
-- **[Development Setup](docs/05-contributing/development-setup.md)** - Contributor environment
-- **[Testing Guide](docs/05-contributing/testing.md)** - Test framework and practices
+# ✅ WASM size: 42.3 KB
+# 🔑 Metadata hash: ...
+# ⭐ Your new template's address: template_f807989828e70a...
+```
 
-## 🔧 Prerequisites
+### Publish metadata to community server
 
-<!-- SOURCE: Verified against actual config defaults -->
-Before using Tari CLI, ensure you have:
+```bash
+# Hash-verified (template must have been published with metadata hash)
+tari metadata publish -t template_f807989828e70a...
 
-- **[Tari Wallet Daemon](https://github.com/tari-project/tari-dan)** running locally
-- **Rust toolchain** with `wasm32-unknown-unknown` target:
-  ```bash
-  rustup target add wasm32-unknown-unknown
-  ```
+# Author-signed (signs via wallet daemon, no secret keys in the CLI)
+tari metadata publish -t template_f807989828e70a... --signed
+```
 
-The CLI automatically detects your development environment and guides you through any missing setup.
+## Commands
 
-## 🌐 Networks
+| Command | Description |
+|---------|-------------|
+| `tari create [NAME]` | Create a new template crate (interactive if name omitted) |
+| `tari build [PATH]` | Build the WASM binary |
+| `tari publish [PATH]` | Publish template to the network |
+| `tari template init` | Set up metadata generation in an existing crate |
+| `tari template inspect` | Inspect built metadata |
+| `tari metadata publish` | Publish metadata to a community server |
+| `tari metadata inspect` | Inspect built metadata (alias) |
+| `tari config init/set/get/show` | Manage project configuration |
 
-- **Local Development**: Perfect for testing and iteration
-- **Testnet**: Pre-production validation
-- **Mainnet**: Production publishing
+Run `tari --help` or `tari <command> --help` for full details.
 
-See the [Configuration Guide](docs/02-guides/project-configuration.md) for network-specific setup.
+## Configuration
 
-## 🆘 Get Help
+Project config lives in `tari.config.toml` (created by `tari config init` or the wizard):
 
-- **📖 Documentation**: Comprehensive guides above
-- **🐛 Bug Reports**: [GitHub Issues](https://github.com/tari-project/tari-cli/issues)
-- **💬 Community**: [Tari Discord](https://discord.gg/tari)
-- **📧 Questions**: [GitHub Discussions](https://github.com/tari-project/tari/discussions)
+```toml
+[network]
+wallet-daemon-jrpc-address = "http://127.0.0.1:9000/json_rpc"
 
-## 📊 Project Status
+# metadata-server-url = "http://localhost:3000"
+# default_account = "myaccount"
+```
 
-- **Build Status**: [![CI](https://img.shields.io/github/actions/workflow/status/tari-project/tari-cli/pr-check.yml)](https://github.com/tari-project/tari-cli/actions/workflows/pr-check.yml)
-- **Latest Release**: [![Release](https://img.shields.io/github/v/release/tari-project/tari-cli)](https://github.com/tari-project/tari-cli/releases)
-- **Crates.io**: [![Crates.io](https://img.shields.io/crates/v/tari-ootle-cli)](https://crates.io/crates/tari-ootle-cli)
+Settings are resolved: **CLI flag > project config > global config > default**.
 
----
+See the [Configuration Schema Reference](https://tari-project.github.io/tari-cli/03-reference/configuration-schema/) for all options.
 
-**Ready to build the future of decentralized applications?** [Get started now](docs/01-getting-started/installation.md) or explore our [template gallery](docs/02-guides/template-development.md#template-examples).
+## Documentation
+
+Full documentation is available at **[tari-project.github.io/tari-cli](https://tari-project.github.io/tari-cli/)**.
+
+- [CLI Commands Reference](https://tari-project.github.io/tari-cli/03-reference/cli-commands/)
+- [Configuration Schema](https://tari-project.github.io/tari-cli/03-reference/configuration-schema/)
+- [Getting Started](https://tari-project.github.io/tari-cli/01-getting-started/quick-start/)
+
+## Prerequisites
+
+- [Tari Wallet Daemon](https://github.com/tari-project/tari-dan) running and accessible
+- Rust toolchain with `wasm32-unknown-unknown` target
+
+## License
+
+BSD-3-Clause. See [LICENSE](LICENSE).

--- a/docs/03-reference/cli-commands.md
+++ b/docs/03-reference/cli-commands.md
@@ -1,9 +1,9 @@
 ---
 title: CLI Commands Reference
 description: Complete reference for all Tari CLI commands, arguments, and options
-last_updated: 2025-06-26
-version: Latest (main branch)
-verified_against: crates/cli/src/cli/arguments.rs, command implementations
+last_updated: 2026-04-07
+version: "0.11"
+verified_against: crates/cli/src/cli/command.rs, command implementations
 audience: users
 ---
 
@@ -13,14 +13,11 @@ audience: users
 
 ## Global Options
 
-<!-- SOURCE: crates/cli/src/cli/arguments.rs:88-104 -->
 Available for all commands:
 
 ```bash
 tari [GLOBAL_OPTIONS] <COMMAND> [COMMAND_OPTIONS]
 ```
-
-### Global Arguments
 
 | Option | Short | Description | Default |
 |--------|-------|-------------|---------|
@@ -28,367 +25,256 @@ tari [GLOBAL_OPTIONS] <COMMAND> [COMMAND_OPTIONS]
 | `--config-file-path <PATH>` | `-c` | Config file location | `~/.config/tari_cli/tari.config.toml` |
 | `--config-overrides <KEY=VALUE>` | `-e` | Config file overrides | None |
 
-### Global Examples
-
-```bash
-# Use custom base directory
-tari -b ~/my-tari-data create my-project
-
-# Override configuration
-tari -e "project_template_repository.url=https://github.com/my-org/templates" create my-project
-
-# Use custom config file
-tari -c ./custom-config.toml publish --account test my-template
-```
-
 ## Commands Overview
 
-<!-- SOURCE: crates/cli/src/cli/arguments.rs:121-138 -->
-The Tari CLI provides three main commands:
-
-| Command | Purpose | Typical Usage |
-|---------|---------|---------------|
-| **[`create`](#create-command)** | Creates new Tari template projects | Start new development workspace |
-| **[`new`](#new-command)** | Creates new WASM template projects | Add smart contracts to existing projects |
-| **[`publish`](#publish-command)** | Publishes templates to Tari network | Publish contracts to blockchain |
+| Command | Alias | Purpose |
+|---------|-------|---------|
+| [`create`](#create) | `new` | Create a new template crate from a starter template |
+| [`build`](#build) | | Build the template WASM binary |
+| [`publish`](#publish) | `deploy` | Publish a template to the network |
+| [`template`](#template) | | Template metadata tooling (init, inspect, publish) |
+| [`metadata`](#metadata) | | Metadata server operations (inspect, publish) |
+| [`config`](#config) | | Manage project configuration |
+| *(no command)* | | [Interactive setup wizard](#wizard) |
 
 ---
 
-## `create` Command
+## `create`
 
-<!-- SOURCE: crates/cli/src/cli/commands/create.rs:23-38 -->
-Creates a new Tari templates project with complete development environment.
-
-### Syntax
+Creates a new Tari template crate from a starter template. Alias: `new`.
 
 ```bash
-tari create [OPTIONS] <NAME>
+tari create [OPTIONS] [NAME]
 ```
 
-### Arguments
+| Argument / Option | Type | Default | Description |
+|-------------------|------|---------|-------------|
+| `[NAME]` | String | *prompted* | Name of the new template crate (converted to snake_case). If omitted, you will be prompted |
+| `-t, --template` | String | *prompted* | Template to use (e.g. "fungible", "meme_coin"). Prompted if not set |
+| `-o, --output <PATH>` | Path | Current directory | Directory where the new crate will be created |
+| `--skip-init` | Flag | `false` | Skip git repository initialisation |
+| `--skip-metadata` | Flag | `false` | Skip automatic template metadata initialisation |
+| `-v, --verbose` | Flag | `false` | Enable verbose output |
 
-| Argument | Type | Description | Validation |
-|----------|------|-------------|------------|
-| `<NAME>` | String | Name of the project | Converted to snake_case |
+### Example
 
-### Options
-
-| Option | Short | Type | Description | Default |
-|--------|-------|------|-------------|---------|
-| `--template <TEMPLATE>` | `-t` | String | Selected project template ID | Interactive selection |
-| `--target <PATH>` | | Path | Target folder for new project | Current directory |
-
-### Behavior
-
-1. **Repository Refresh**: Downloads/updates template repositories
-2. **Template Discovery**: Scans for available project templates
-3. **Template Selection**: Interactive selection or use specified template
-4. **Project Generation**: Uses `cargo-generate` to create project structure
-5. **Configuration**: Sets up `tari.config.toml` with network defaults
-
-### Examples
-
-**Basic Project Creation**:
 ```bash
-# Interactive template selection
-tari create my-defi-project
+# Interactive — prompts for name and template
+tari create
 
-# Specify template directly
-tari create my-nft-project --template basic
-
-# Create in specific directory
-tari create my-project --target ~/projects/tari/
-```
-
-**Expected Output**:
-```
-✅ Init configuration and directories
-✅ Refresh project templates repository
-✅ Refresh wasm templates repository
-✅ Collecting available project templates
-🔎 Select project template: Basic - The basic project template to get started
-⠋ Generate new project[1/5] ⠁
-✅ Generate new project
-```
-
-### Generated Structure
-
-```
-my-project/
-├── Cargo.toml              # Workspace configuration
-├── tari.config.toml        # Network settings
-├── templates/              # Directory for WASM templates
-└── README.md               # Project documentation
+# Specify everything
+tari create my-token --template fungible -o ~/projects/
 ```
 
 ---
 
-## `new` Command
+## `build`
 
-<!-- SOURCE: crates/cli/src/cli/commands/new.rs:21-36 -->
-Creates a new Tari WASM template (smart contract) within an existing project.
-
-### Syntax
+Builds the template WASM binary and reports the metadata CBOR file path (if present).
 
 ```bash
-tari new [OPTIONS] <NAME>
+tari build [PATH]
 ```
 
-### Arguments
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `[PATH]` | Path | `.` | Path to the template crate directory |
 
-| Argument | Type | Description | Validation |
-|----------|------|-------------|------------|
-| `<NAME>` | String | Name of the template | Converted to snake_case |
+### Example
 
-### Options
-
-| Option | Short | Type | Description | Default |
-|--------|-------|------|-------------|---------|
-| `--template <TEMPLATE>` | `-t` | String | Selected WASM template ID | Interactive selection |
-| `--target <PATH>` | | Path | Target folder for new template | Current directory |
-
-### Behavior
-
-1. **Repository Refresh**: Updates WASM template repositories
-2. **Template Discovery**: Scans for available WASM templates
-3. **Workspace Detection**: Automatically detects Cargo workspace
-4. **Directory Selection**: Uses `templates/` subdirectory if available
-5. **Template Generation**: Creates smart contract from template
-6. **Workspace Update**: Adds new template to `Cargo.toml` workspace members
-
-### Examples
-
-**Basic Template Creation**:
 ```bash
-# Interactive template selection
-tari new MyNFT
-
-# Specify template type
-tari new MyToken --template fungible-token
-
-# Create in specific directory
-tari new MyDAO --target ./contracts/
-```
-
-**Expected Output**:
-```
-✅ Init configuration and directories
-✅ Refresh project templates repository
-✅ Refresh wasm templates repository
-✅ Collecting available WASM templates
-🔎 Select WASM template: NFT - A simple NFT template to create your own
-⠋ Generate new project[1/10] ⠁
-✅ Generate new project
-✅ Update Cargo.toml
-```
-
-### Generated Structure
-
-```
-templates/my_nft/
-├── Cargo.toml              # Template dependencies
-├── src/
-│   └── lib.rs             # Smart contract implementation
-└── README.md              # Template documentation
+tari build
+# ✅ WASM binary: target/wasm32.../release/my_token.wasm (42.3 KB)
+# 📄 Metadata:    target/wasm32.../release/build/.../out/template_metadata.cbor
 ```
 
 ---
 
-## `publish` Command
+## `publish`
 
-<!-- SOURCE: crates/cli/src/cli/commands/publish.rs:18-50 -->
-Publishes a Tari template to the blockchain network. (Also available as `deploy` for backward compatibility.)
-
-### Syntax
+Publishes a template to the Tari network. Alias: `deploy`. Delegates to `tari template publish`.
 
 ```bash
-tari publish [OPTIONS] <TEMPLATE>
+tari publish [OPTIONS] [PATH]
 ```
 
-### Arguments
+| Argument / Option | Type | Default | Description |
+|-------------------|------|---------|-------------|
+| `[PATH]` | Path | `.` | Path to the template crate directory |
+| `-a, --account` | String | Config or wallet default | Account for publishing fees |
+| `-c, --custom-network` | String | Config default | Custom network name |
+| `-y, --yes` | Flag | `false` | Skip confirmation prompt |
+| `-f, --max-fee` | u64 | Auto-estimated | Maximum fee in microtari |
+| `--binary, --bin` | Path | *builds if not set* | Path to pre-compiled WASM binary |
+| `--wallet-daemon-url` | URL | Config default | Wallet daemon JSON-RPC URL |
+| `--publish-metadata` | Flag | `false` | Auto-submit metadata to server after publishing |
+| `--metadata-server-url` | URL | Config or `localhost:3000` | Metadata server URL (with `--publish-metadata`) |
 
-| Argument | Type | Description | Validation |
-|----------|------|-------------|------------|
-| `<TEMPLATE>` | String | Template project to publish | Must exist in workspace |
+### Example
 
-### Options
-
-| Option | Short | Type | Description | Default |
-|--------|-------|------|-------------|---------|
-| `--account <ACCOUNT>` | `-a` | String | Account for publishing fees | **Required** |
-| `--custom-network <NETWORK>` | `-c` | String | Custom network name | Uses config default |
-| `--yes` | `-y` | Flag | Confirm publishing without prompt | `false` |
-| `--max-fee <MAX_FEE>` | `-f` | u64 | Maximum publishing fee | Auto-estimated |
-| `--project-folder <PATH>` | | Path | Project folder location | Current directory |
-
-### Behavior
-
-1. **Configuration Loading**: Reads `tari.config.toml` for network settings
-2. **Project Discovery**: Locates template in Cargo workspace
-3. **WASM Compilation**: Builds template for `wasm32-unknown-unknown` target
-4. **Fee Estimation**: Calculates publishing cost
-5. **Balance Verification**: Checks account has sufficient funds
-6. **Publishing**: Submits template to Tari network via wallet daemon
-7. **Address Return**: Provides published template address
-
-### Examples
-
-**Basic Publishing**:
 ```bash
-# Publish with confirmation prompt
-tari publish --account myaccount my_nft
+# Build and publish
+tari publish -a myaccount -y
 
-# Publish with auto-confirmation
-tari publish --account myaccount --yes my_token
-
-# Publish to custom network
-tari publish --account testaccount --custom-network testnet my_dao
-
-# Publish with fee limit
-tari publish --account myaccount --max-fee 100000 my_template
-```
-
-**Expected Output**:
-```
-✅ Init configuration and directories
-✅ Refresh project templates repository  
-✅ Refresh wasm templates repository
-✅ Building WASM template project "my_nft"
-❓Publishing this template costs 256875 XTR (estimated), are you sure to continue? yes
-✅ Publishing project "my_nft" to local network
-⭐ Your new template's address: f807989828e70a18050e5785f30a7bd01475797d76d6b4700af175b859c32774
-```
-
-### Prerequisites
-
-- **Wallet Daemon**: Must be running and accessible
-- **Account**: Must exist with sufficient balance
-- **Network Access**: Must be configured for target network
-- **WASM Target**: `wasm32-unknown-unknown` must be installed
-
----
-
-## Error Handling
-
-### Common Error Messages
-
-<!-- SOURCE: crates/cli/src/cli/commands/create.rs:42 -->
-**Template Not Found**:
-```
-Template not found by name: basic. Possible values: ["advanced", "minimal", "nft"]
-```
-**Solution**: Use `tari create` without `--template` to see available options.
-
-**Workspace Not Found**:
-```
-Project is not a Cargo workspace project!
-```
-**Solution**: Run command from project root with `Cargo.toml` workspace.
-
-**Account Not Found**:
-```
-Account "nonexistent" not found
-```
-**Solution**: Verify account exists in wallet daemon.
-
-**Insufficient Funds**:
-```
-Insufficient funds for publishing
-```
-**Solution**: Add funds to account or use `--max-fee` to limit cost.
-
-### Debugging Commands
-
-**Check CLI Configuration**:
-```bash
-# Verify CLI installation
-tari --version
-
-# Show help for specific command
-tari create --help
-tari new --help  
-tari publish --help
-```
-
-**Test Repository Access**:
-```bash
-# This will test template repository connectivity
-tari create test-connectivity
-
-# Cancel when template selection appears
-# Success = repositories are accessible
-```
-
-**Verify Wallet Connection**:
-```bash
-curl -X POST http://127.0.0.1:9000/ \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"ping"}'
-```
-
-## Environment Variables
-
-While not directly supported, these environment variables affect CLI behavior:
-
-| Variable | Effect | Example |
-|----------|--------|---------|
-| `RUST_LOG` | Enable debug logging | `RUST_LOG=debug tari create my-project` |
-| `CARGO_TARGET_DIR` | Override cargo build directory | `CARGO_TARGET_DIR=./build tari publish` |
-| `HOME` | Affects default directories | Automatically detected |
-
-## Configuration Integration
-
-Commands interact with configuration files:
-
-- **Global CLI Config**: `~/.config/tari_cli/tari.config.toml`
-- **Project Config**: `project_dir/tari.config.toml`
-- **Command-line Overrides**: `--config-overrides KEY=VALUE`
-
-**Precedence**: CLI args > Project config > Global config > Defaults
-
-## Advanced Usage
-
-### Scripting and Automation
-
-**Automated Project Creation**:
-```bash
-#!/bin/bash
-PROJECT_NAME="automated-project"
-TEMPLATE_TYPE="basic"
-
-tari create "$PROJECT_NAME" --template "$TEMPLATE_TYPE"
-cd "$PROJECT_NAME"
-tari new "MyContract" --template "nft"
-```
-
-**Batch Publishing**:
-```bash
-#!/bin/bash
-ACCOUNT="publishing-account"
-
-for template in templates/*/; do
-    template_name=$(basename "$template")
-    tari publish --account "$ACCOUNT" --yes "$template_name"
-done
-```
-
-### Integration with Build Systems
-
-**Makefile Integration**:
-```makefile
-publish: build
-	tari publish --account $(ACCOUNT) --yes $(TEMPLATE)
-
-build:
-	cargo build --target wasm32-unknown-unknown --release
-
-test:
-	cargo test --workspace
+# Publish and auto-submit metadata
+tari publish -a myaccount --publish-metadata --metadata-server-url http://community.example.com
 ```
 
 ---
 
-For complete examples and advanced usage patterns, see:
-- **[Quick Start Guide](../01-getting-started/quick-start.md)** - End-to-end examples
-- **[Template Development](../02-guides/template-development.md)** - Custom template creation
-- **[Troubleshooting](../04-troubleshooting/common-issues.md)** - Issue resolution
+## `template`
+
+Template metadata tooling.
+
+### `template init`
+
+Sets up an existing template crate for metadata generation. Alias: `template init-metadata`.
+
+```bash
+tari template init [OPTIONS] [PATH]
+```
+
+| Argument / Option | Type | Default | Description |
+|-------------------|------|---------|-------------|
+| `[PATH]` | Path | `.` | Path to template crate directory |
+| `--tags` | String (comma-separated) | *prompted* | Tags (e.g. "token,fungible,defi") |
+| `--category` | String | *prompted* | Template category |
+| `--documentation` | String | *prompted* | Documentation URL |
+| `--homepage` | String | *prompted* | Homepage URL |
+| `--logo-url` | String | *prompted* | Logo URL |
+| `-y, --non-interactive` | Flag | `false` | Skip interactive prompts |
+
+Adds `tari_ootle_template_build` to `[build-dependencies]`, creates `build.rs`, and writes a `[package.metadata.tari-template]` section to `Cargo.toml`.
+
+### `template inspect`
+
+Inspects a template metadata CBOR file. Alias: `template inspect-metadata`.
+
+```bash
+tari template inspect [OPTIONS] [PATH]
+```
+
+| Argument / Option | Type | Default | Description |
+|-------------------|------|---------|-------------|
+| `[PATH]` | Path | *searches build output* | Path to metadata CBOR file |
+| `--project-dir` | Path | `.` | Project directory to search (when path not given) |
+| `--json` | Flag | `false` | Output as JSON |
+
+### `template publish`
+
+Publishes a template with its metadata hash. Same options as [`publish`](#publish).
+
+---
+
+## `metadata`
+
+Template metadata server operations.
+
+### `metadata inspect`
+
+Alias for [`template inspect`](#template-inspect).
+
+### `metadata publish`
+
+Publishes template metadata to a community metadata server.
+
+```bash
+tari metadata publish [OPTIONS] -t <TEMPLATE_ADDRESS>
+```
+
+| Argument / Option | Type | Default | Description |
+|-------------------|------|---------|-------------|
+| `[PATH]` | Path | `.` | Path to template crate directory |
+| `-t, --template-address` | Address | **required** | Template address (e.g. `template_bce07f...` or raw hex) |
+| `--metadata-server-url` | URL | Config or `localhost:3000` | Metadata server URL |
+| `--max-retries` | u32 | `6` | Max retry attempts for 404 (template not yet synced) |
+| `--signed` | Flag | `false` | Use author-signed submission via wallet daemon |
+| `--key-index` | u64 | `0` | Derived account key index (with `--signed`) |
+| `--wallet-daemon-url` | URL | Config default | Wallet daemon URL (with `--signed`) |
+
+#### Hash-verified (default)
+
+POSTs raw CBOR metadata. The server verifies the hash matches the on-chain `metadata_hash`. Requires the template to have been published with a metadata hash.
+
+```bash
+tari metadata publish -t template_bce07f...
+```
+
+#### Author-signed (`--signed`)
+
+Signs metadata via the wallet daemon (Schnorr signature). Allows updating metadata without republishing on-chain. No secret keys touch the CLI.
+
+```bash
+tari metadata publish -t template_bce07f... --signed --key-index 0
+```
+
+Both flows retry with exponential backoff on 404 (template not yet synced by the server).
+
+---
+
+## `config`
+
+Manage project configuration (`tari.config.toml`).
+
+### `config init`
+
+Creates a `tari.config.toml` with defaults in the project root (or git repo root).
+
+```bash
+tari config init
+```
+
+### `config set`
+
+Sets a configuration value.
+
+```bash
+tari config set <KEY> <VALUE>
+```
+
+Examples:
+```bash
+tari config set network.wallet-daemon-jrpc-address http://localhost:12008/json_rpc
+tari config set metadata_server_url http://community.example.com
+tari config set default_account myaccount
+```
+
+### `config get`
+
+```bash
+tari config get <KEY>
+```
+
+### `config show`
+
+Displays the full configuration file.
+
+```bash
+tari config show
+```
+
+---
+
+## Wizard
+
+Running `tari` with no command launches an interactive setup wizard that walks you through:
+
+1. Creating or detecting a template crate
+2. Setting up project configuration (`tari.config.toml`)
+3. Initialising template metadata
+
+---
+
+## Configuration Resolution
+
+Settings are resolved in priority order (highest first):
+
+| Setting | CLI flag | Project config | Global config | Default |
+|---------|----------|---------------|---------------|---------|
+| Wallet daemon URL | `--wallet-daemon-url` | `network.wallet-daemon-jrpc-address` | `wallet_daemon_url` | `http://127.0.0.1:9000/json_rpc` |
+| Metadata server URL | `--metadata-server-url` | `metadata-server-url` | `metadata_server_url` | `http://localhost:3000` |
+| Account | `--account` | `default_account` | `default_account` | Wallet daemon default |
+
+---
+
+For configuration file details, see the [Configuration Schema Reference](configuration-schema.md).

--- a/docs/03-reference/configuration-schema.md
+++ b/docs/03-reference/configuration-schema.md
@@ -1,462 +1,243 @@
 ---
 title: Configuration Schema Reference
 description: Complete reference for all Tari CLI configuration options and file formats
-last_updated: 2025-06-26
-version: Latest (main branch)
+last_updated: 2026-04-07
+version: "0.11"
 verified_against: crates/cli/src/cli/config.rs, crates/cli/src/project/config.rs
 audience: users
 ---
 
 # Configuration Schema Reference
 
-> **Complete reference** for all Tari CLI configuration files, options, and environment variables
+> **Complete reference** for all Tari CLI configuration files and options
 
 ## Configuration Hierarchy
 
-The Tari CLI uses a hierarchical configuration system with the following precedence (highest to lowest):
+Settings are resolved in this order (highest priority first):
 
-1. **Command-line arguments** (`--account`, `--max-fee`, etc.)
+1. **Command-line flags** (`--wallet-daemon-url`, `--metadata-server-url`, etc.)
 2. **CLI overrides** (`-e KEY=VALUE`)
-3. **Project configuration** (`project_dir/tari.config.toml`)
+3. **Project configuration** (`tari.config.toml` in project or git root)
 4. **Global CLI configuration** (`~/.config/tari_cli/tari.config.toml`)
 5. **Built-in defaults**
 
+---
+
 ## Global CLI Configuration
 
-<!-- SOURCE: Verified against crates/cli/src/cli/config.rs -->
 ### File Location
 
-**Default path**: `~/.config/tari_cli/tari.config.toml`
+**Default**: `~/.config/tari_cli/tari.config.toml`
 
-**Custom path**: Use `--config-file-path` or `-c` flag
+**Custom**: use `--config-file-path` or `-c`
 
-### CLI Configuration Schema
+### Schema
 
 ```toml
 # ~/.config/tari_cli/tari.config.toml
 
-[project-template-repository]
-url = "https://github.com/tari-project/wasm-template"
-branch = "main"
-folder = "project_templates"
-
-[wasm-template-repository]  
+[template-repository]
 url = "https://github.com/tari-project/wasm-template"
 branch = "main"
 folder = "wasm_templates"
+
+# Optional
+# wallet-daemon-url = "http://127.0.0.1:9000/json_rpc"
+# metadata-server-url = "http://localhost:3000"
+# default-account = "myaccount"
 ```
 
-### CLI Configuration Fields
+### Fields
 
-<!-- SOURCE: Verified against config.rs lines 22-51 -->
-#### `[project-template-repository]`
+#### `[template-repository]`
 
-Controls where project templates are sourced from:
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `url` | String | `https://github.com/tari-project/wasm-template` | Git repository URL for templates |
+| `branch` | String | `main` | Git branch |
+| `folder` | String | `wasm_templates` | Subdirectory containing templates |
 
-| Field | Type | Description | Default |
-|-------|------|-------------|---------|
-| `url` | String | Git repository URL for project templates | `"https://github.com/tari-project/wasm-template"` |
-| `branch` | String | Git branch to use | `"main"` |
-| `folder` | String | Subdirectory containing templates | `"project_templates"` |
+#### Top-level optional fields
 
-#### `[wasm-template-repository]`
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `wallet-daemon-url` | URL | None | Global wallet daemon JSON-RPC URL |
+| `metadata-server-url` | URL | None | Global metadata server URL |
+| `default-account` | String | None | Default wallet account for publishing |
 
-Controls where WASM templates are sourced from:
+### CLI Overrides (`-e`)
 
-| Field | Type | Description | Default |
-|-------|------|-------------|---------|
-| `url` | String | Git repository URL for WASM templates | `"https://github.com/tari-project/wasm-template"` |
-| `branch` | String | Git branch to use | `"main"` |
-| `folder` | String | Subdirectory containing templates | `"wasm_templates"` |
+Valid override keys:
 
-### CLI Configuration Overrides
-
-<!-- SOURCE: Verified against config.rs VALID_OVERRIDE_KEYS lines 10-17 -->
-Override configuration via command line:
+| Key | Example |
+|-----|---------|
+| `template_repository.url` | `https://github.com/my-org/templates` |
+| `template_repository.branch` | `development` |
+| `template_repository.folder` | `my_templates` |
+| `default_account` | `myaccount` |
+| `wallet_daemon_url` | `http://localhost:12008/json_rpc` |
+| `metadata_server_url` | `http://community.example.com` |
 
 ```bash
-# Override project template repository
-tari -e "project_template_repository.url=https://github.com/my-org/templates" create my-project
-
-# Override template branch
-tari -e "wasm_template_repository.branch=development" new my-template
-
-# Multiple overrides
-tari -e "project_template_repository.url=https://custom.git" \
-     -e "wasm_template_repository.branch=custom" \
-     create my-project
+tari -e "wallet_daemon_url=http://localhost:12008/json_rpc" publish
 ```
 
-**Valid Override Keys**:
-- `project_template_repository.url`
-- `project_template_repository.branch`
-- `project_template_repository.folder`
-- `wasm_template_repository.url`
-- `wasm_template_repository.branch`
-- `wasm_template_repository.folder`
+---
 
 ## Project Configuration
 
-<!-- SOURCE: Verified against crates/cli/src/project/config.rs -->
 ### File Location
 
-**Required location**: `{project_root}/tari.config.toml`
+`tari.config.toml` in the project root or git repository root. Created with `tari config init` or automatically by the wizard.
 
-### Project Configuration Schema
+### Schema
 
 ```toml
-# tari.config.toml (in project root)
+# tari.config.toml
 
 [network]
-wallet-daemon-jrpc-address = "http://127.0.0.1:9000/"
+wallet-daemon-jrpc-address = "http://127.0.0.1:9000/json_rpc"
+
+# Optional
+# default_account = "myaccount"
+# metadata-server-url = "http://localhost:3000"
 ```
 
-### Project Configuration Fields
+### Fields
 
-<!-- SOURCE: Verified against project/config.rs lines 16-33 -->
 #### `[network]`
 
-Network and publishing configuration:
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `wallet-daemon-jrpc-address` | URL | `http://127.0.0.1:9000/json_rpc` | Wallet daemon JSON-RPC endpoint |
 
-| Field | Type | Description | Default | Required |
-|-------|------|-------------|---------|----------|
-| `wallet-daemon-jrpc-address` | String (URL) | JSON-RPC endpoint for Tari Wallet Daemon | `"http://127.0.0.1:9000/"` | Yes |
+#### Top-level optional fields
 
-**URL Format Requirements**:
-- Must be valid HTTP/HTTPS URL
-- Must include protocol (`http://` or `https://`)
-- Must include port number
-- Examples: `http://127.0.0.1:9000/`, `https://testnet-node:9000/`
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `default_account` | String | None | Default wallet account |
+| `metadata-server-url` | URL | None | Metadata server URL |
 
-### Network Configuration Examples
+### Managing Project Configuration
 
-**Local Development**:
-```toml
-[network]
-wallet-daemon-jrpc-address = "http://127.0.0.1:9000/"
+```bash
+# Create default config
+tari config init
+
+# Set wallet daemon URL
+tari config set network.wallet-daemon-jrpc-address http://localhost:12008/json_rpc
+
+# Set metadata server
+tari config set metadata_server_url http://community.example.com
+
+# View current config
+tari config show
 ```
 
-**Remote Testnet**:
+---
+
+## Template Metadata Configuration
+
+Template metadata is stored in `Cargo.toml` under `[package.metadata.tari-template]`. It is read at build time by `tari_ootle_template_build` and encoded as CBOR.
+
+### Schema
+
 ```toml
-[network]
-wallet-daemon-jrpc-address = "https://testnet-wallet.tari.com:9000/"
+[package]
+name = "my-template"
+version = "1.0.0"
+description = "A fungible token with mint/burn/transfer"
+license = "BSD-3-Clause"
+repository = "https://github.com/example/my-template"
+
+[package.metadata.tari-template]
+tags = ["token", "fungible", "defi"]
+category = "token"
+documentation = "https://docs.example.com/"
+homepage = "https://example.com/"
+logo_url = "https://example.com/logo.png"
+
+[package.metadata.tari-template.extra]
+audit = "https://example.com/audit-report"
 ```
 
-**Custom Port**:
-```toml
-[network]
-wallet-daemon-jrpc-address = "http://127.0.0.1:9001/"
+### Fields
+
+Fields from `[package]` (read automatically):
+
+| Field | Source | Description |
+|-------|--------|-------------|
+| `name` | `[package].name` | Template name (required) |
+| `version` | `[package].version` | Template version (required) |
+| `description` | `[package].description` | Description |
+| `license` | `[package].license` | License identifier |
+| `repository` | `[package].repository` | Repository URL |
+
+Fields from `[package.metadata.tari-template]`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tags` | Array of strings | Searchable tags |
+| `category` | String | Template category |
+| `documentation` | String | Documentation URL |
+| `homepage` | String | Homepage URL |
+| `logo_url` | String | Logo/icon image URL |
+
+Fields from `[package.metadata.tari-template.extra]`:
+
+Arbitrary key-value pairs (string values only).
+
+### Setting Up Metadata
+
+```bash
+# Interactive setup (adds build.rs and Cargo.toml section)
+tari template init
+
+# Non-interactive
+tari template init -y --tags token,defi --category token --logo-url https://example.com/logo.png
 ```
 
-## Template Configuration
+### Inspecting Metadata
 
-### Template Descriptor Schema
+```bash
+# Human-readable table
+tari metadata inspect
 
-<!-- SOURCE: Verified against crates/cli/src/templates/collector.rs lines 136-152 -->
-Every template requires a `template.toml` file:
+# JSON output
+tari metadata inspect --json
+```
+
+---
+
+## Template Descriptor
+
+Template repositories use `template.toml` to describe each starter template:
 
 ```toml
-# template.toml
+name = "fungible-token"
+description = "A standard fungible token with mint/burn/transfer"
 
-name = "template-name"
-description = "Human-readable template description"
-
-# Optional extra configuration
 [extra]
-templates_dir = "templates"
-wasm_templates = "true"
 category = "tokens"
 complexity = "beginner"
 ```
 
-### Template Fields Reference
-
-#### Required Fields
-
-| Field | Type | Description | Example |
-|-------|------|-------------|---------|
-| `name` | String | Template identifier (converted to snake_case) | `"nft-template"` |
-| `description` | String | Human-readable description shown during selection | `"A simple NFT template"` |
-
-#### Optional `[extra]` Fields
-
-| Field | Type | Description | Usage |
-|-------|------|-------------|-------|
-| `templates_dir` | String | Subdirectory containing template files | Project templates with nested WASM templates |
-| `wasm_templates` | String | Comma-separated list of initial WASM templates | Auto-generate templates on project creation |
-| `category` | String | Template category for organization | `"tokens"`, `"defi"`, `"governance"` |
-| `complexity` | String | Difficulty level indicator | `"beginner"`, `"intermediate"`, `"advanced"` |
-
-### Template Repository Structure
-
-<!-- SOURCE: Verified against collector.rs template discovery logic -->
-Templates are discovered by scanning for `template.toml` files:
-
-```
-template-repository/
-├── basic-project/
-│   ├── template.toml           # Project template descriptor
-│   ├── Cargo.toml             # Project workspace config
-│   └── src/                   # Template source files
-├── templates/
-│   ├── nft/
-│   │   ├── template.toml      # WASM template descriptor  
-│   │   ├── Cargo.toml         # Crate configuration
-│   │   └── src/lib.rs         # Smart contract implementation
-│   └── token/
-│       ├── template.toml
-│       ├── Cargo.toml
-│       └── src/lib.rs
-```
-
-**Discovery Rules**:
-- CLI recursively scans repository for `template.toml` files
-- Template ID derived from directory name (converted to snake_case)
-- Templates can be nested in any directory structure
-- Both root-level and subdirectory templates are supported
-
-## Command-Line Configuration
-
-### Global Arguments
-
-<!-- SOURCE: Verified against crates/cli/src/cli/arguments.rs lines 88-104 -->
-Available for all commands:
-
-```bash
-tari [GLOBAL_OPTIONS] <COMMAND> [COMMAND_OPTIONS]
-```
-
-| Option | Short | Type | Description | Default |
-|--------|-------|------|-------------|---------|
-| `--base-dir <PATH>` | `-b` | Path | Base directory for CLI data | `~/.local/share/tari_cli` |
-| `--config-file-path <PATH>` | `-c` | Path | Config file location | `~/.config/tari_cli/tari.config.toml` |
-| `--config-overrides <KEY=VALUE>` | `-e` | String | Config overrides | None |
-
-### Command-Specific Arguments
-
-#### `create` Command
-
-```bash
-tari create [OPTIONS] <NAME>
-```
-
-| Option | Short | Type | Description | Default |
-|--------|-------|------|-------------|---------|
-| `<NAME>` | | String | Project name (converted to snake_case) | Required |
-| `--template <TEMPLATE>` | `-t` | String | Project template ID | Interactive selection |
-| `--target <PATH>` | | Path | Target directory | Current directory |
-
-#### `new` Command
-
-```bash
-tari new [OPTIONS] <NAME>
-```
-
-| Option | Short | Type | Description | Default |
-|--------|-------|------|-------------|---------|
-| `<NAME>` | | String | Template name (converted to snake_case) | Required |
-| `--template <TEMPLATE>` | `-t` | String | WASM template ID | Interactive selection |
-| `--target <PATH>` | | Path | Target directory | Current directory |
-
-#### `deploy` Command
-
-<!-- SOURCE: Verified against crates/cli/src/cli/commands/deploy.rs lines 18-50 -->
-```bash
-tari deploy [OPTIONS] <TEMPLATE>
-```
-
-| Option | Short | Type | Description | Default |
-|--------|-------|------|-------------|---------|
-| `<TEMPLATE>` | | String | Template project to deploy | Required |
-| `--account <ACCOUNT>` | `-a` | String | Account for deployment fees | Required |
-| `--custom-network <NETWORK>` | `-c` | String | Custom network name | Project config default |
-| `--yes` | `-y` | Flag | Auto-confirm deployment | `false` |
-| `--max-fee <MAX_FEE>` | `-f` | u64 | Maximum deployment fee | Auto-estimated |
-| `--project-folder <PATH>` | | Path | Project folder location | Current directory |
-
-## Environment Variables
-
-### CLI Data Directories
-
-<!-- SOURCE: Verified against arguments.rs default directory functions -->
-The CLI uses standard system directories:
-
-**Linux/macOS**:
-- **Data**: `~/.local/share/tari_cli/`
-- **Config**: `~/.config/tari_cli/`
-- **Templates**: `~/.local/share/tari_cli/template_repositories/`
-
-**Windows**:
-- **Data**: `%APPDATA%\tari_cli\`
-- **Config**: `%APPDATA%\tari_cli\`
-- **Templates**: `%APPDATA%\tari_cli\template_repositories\`
-
-### Build Environment Variables
-
-These affect WASM compilation and deployment:
-
-| Variable | Effect | Example |
-|----------|--------|---------|
-| `RUST_LOG` | Enable debug logging | `RUST_LOG=debug tari create my-project` |
-| `CARGO_TARGET_DIR` | Override build directory | `CARGO_TARGET_DIR=./build tari publish` |
-| `RUSTFLAGS` | Pass flags to Rust compiler | `RUSTFLAGS="-C target-cpu=native"` |
-
-### Network Environment Variables
-
-<!-- SOURCE: Verified against CI configuration -->
-Used in CI/CD and testing:
-
-| Variable | Effect | Example |
-|----------|--------|---------|
-| `TARI_NETWORK` | Set target network | `TARI_NETWORK=testnet` |
-| `TARI_TARGET_NETWORK` | Set deployment target | `TARI_TARGET_NETWORK=localnet` |
-
-## Validation and Errors
-
-### Configuration Validation
-
-The CLI validates all configuration at startup:
-
-**URL Validation**:
-```rust
-// Must be valid URL with protocol and port
-Url::parse("http://127.0.0.1:9000/").unwrap()
-```
-
-**Override Key Validation**:
-```rust
-// Only specific keys are allowed for overrides
-const VALID_OVERRIDE_KEYS: &[&str] = &[
-    "project_template_repository.url",
-    "wasm_template_repository.branch",
-    // ... other valid keys
-];
-```
-
-### Common Configuration Errors
-
-**Invalid URL Format**:
-```
-Error: URL parsing error: invalid port number
-```
-**Solution**: Ensure URL includes protocol and valid port
-
-**Invalid Override Key**:
-```
-Error: Invalid key: invalid.override.key
-```
-**Solution**: Use only valid override keys from reference
-
-**Missing Configuration File**:
-```
-Failed to load project config file (at /path/to/tari.config.toml)
-```
-**Solution**: Create `tari.config.toml` in project root
-
-**Invalid TOML Syntax**:
-```
-Error: Failed to deserialize TOML
-```
-**Solution**: Validate TOML syntax and field names
-
-## Configuration Examples
-
-### Development Setup
-
-Complete configuration for local development:
-
-```toml
-# ~/.config/tari_cli/tari.config.toml
-[project-template-repository]
-url = "https://github.com/tari-project/wasm-template"
-branch = "main"
-folder = "project_templates"
-
-[wasm-template-repository]
-url = "https://github.com/tari-project/wasm-template"  
-branch = "main"
-folder = "wasm_templates"
-```
-
-```toml
-# project_root/tari.config.toml
-[network]
-wallet-daemon-jrpc-address = "http://127.0.0.1:9000/"
-```
-
-### Multi-Environment Setup
-
-Different configurations for various environments:
-
-**Development** (`tari.config.dev.toml`):
-```toml
-[network]
-wallet-daemon-jrpc-address = "http://127.0.0.1:9000/"
-```
-
-**Testnet** (`tari.config.testnet.toml`):
-```toml
-[network]
-wallet-daemon-jrpc-address = "https://testnet-wallet:9000/"
-```
-
-**Production** (`tari.config.prod.toml`):
-```toml
-[network]
-wallet-daemon-jrpc-address = "https://mainnet-wallet.secure.com:9000/"
-```
-
-### Custom Template Repository
-
-Using organization-specific templates:
-
-```toml
-# ~/.config/tari_cli/tari.config.toml
-[project-template-repository]
-url = "https://github.com/my-org/tari-templates"
-branch = "stable"
-folder = "projects"
-
-[wasm-template-repository]
-url = "https://github.com/my-org/tari-templates"
-branch = "stable"  
-folder = "contracts"
-```
-
-### CI/CD Configuration
-
-Minimal configuration for automated environments:
-
-```bash
-# Environment-based configuration
-export TARI_NETWORK=testnet
-export CARGO_TARGET_DIR=/tmp/build
-
-# CLI with overrides
-tari -b /tmp/tari_cli \
-     -e "wasm_template_repository.branch=ci-stable" \
-     deploy --account ci-account --yes my_template
-```
-
-## Migration and Upgrades
-
-### Configuration Version Compatibility
-
-The CLI maintains backward compatibility for configuration files:
-
-- **Missing fields**: Filled with defaults
-- **Extra fields**: Ignored gracefully  
-- **Deprecated fields**: Warnings displayed
-
-### Migrating Between Versions
-
-When upgrading Tari CLI:
-
-1. **Backup existing config**: Copy current `tari.config.toml` files
-2. **Check deprecation warnings**: Note any warnings on startup
-3. **Update templates**: Refresh template repositories after upgrade
-4. **Validate deployment**: Test deployment on development network
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Template identifier |
+| `description` | Yes | Shown during interactive selection |
+| `[extra]` | No | Arbitrary metadata |
 
 ---
 
-**Need help with configuration?** Check our [Common Issues](../04-troubleshooting/common-issues.md#project-configuration-issues) or [CLI Commands Reference](cli-commands.md) for specific usage examples.
+## Data Directories
+
+| Directory | macOS/Linux | Purpose |
+|-----------|-------------|---------|
+| Data | `~/.local/share/tari_cli/` | CLI data and cached repos |
+| Config | `~/.config/tari_cli/` | Global config file |
+| Templates | `~/.local/share/tari_cli/template_repositories/` | Cloned template repos |
+
+---
+
+For command usage, see the [CLI Commands Reference](cli-commands.md).


### PR DESCRIPTION
## Summary
- Rewrites CLI commands reference to cover all current commands (build, template, metadata, config, wizard)
- Updates configuration schema reference with metadata_server_url, template metadata fields, project config management
- Rewrites README with concise quick-start, command table, and docs badge
- Removes references to removed commands (standalone `new`, `deploy`)

## Test plan
- [ ] Verify docs render correctly on GitHub
- [ ] Check all command descriptions match `tari --help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)