### PR TITLE
fix: metadata CBOR lookup, save template address, validate freshness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,9 +135,9 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -1848,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -3260,9 +3260,9 @@ checksum = "0c6639b70a7ce854b79c70d7e83f16b5dc0137cc914f3d7d03803b513ecc67ac"
 
 [[package]]
 name = "libz-sys"
-version = "1.1.25"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "libc",
@@ -3728,9 +3728,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ootle_byte_type"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da67449d365871bf7ac1d723b20142a1d531c0cb49f7e692a98a20cf5d455f9"
+checksum = "b45546b0e24eaeba4ec7991029fa74732141a3514d02164ea10dbb7ec71053ac"
 dependencies = [
  "tari_crypto",
  "tari_template_lib_types",
@@ -4106,7 +4106,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.10+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -4939,9 +4939,9 @@ checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -5487,7 +5487,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
- "toml_edit 0.25.10+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
  "url",
 ]
 
@@ -5587,9 +5587,9 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.28.4"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41880b184b18477fbac15c8ac1a70fff26d78d84430805f0918bf6f8e801cfd7"
+checksum = "701c634d2c98ea456f34cdaf682cd8f16e226ef689214eb5d293186c51fa187a"
 dependencies = [
  "borsh",
  "ootle_serde",
@@ -5628,9 +5628,9 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.28.4"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b085cfb544ddaa684f0dc36dc4b7cd30504f043d231ab05c7b0e8f654dd036"
+checksum = "f2531f5fc762f2401e8786430e81860895dd1671fe625fb90da6f522749e4171"
 dependencies = [
  "blake2",
  "indexmap 2.13.1",
@@ -5655,9 +5655,9 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.28.4"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7ac84fedb096beb19f5632b30d1ee13d6c143cfbb0f65281609e60059903ecd"
+checksum = "42f30cd34e65d6461caa95b7eadff16dec2c5d5d0934d5a5034a7c18a0ecc45f"
 dependencies = [
  "blake2",
  "borsh",
@@ -5701,9 +5701,9 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.28.4"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b963b46fd84e2b951e9c26a19115433fac087d9812a4b4c28bde153c6d88953"
+checksum = "3919462b04010934ac577c15e876f0a857f7b93fc8737be158ddcee1995de2c5"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -5752,9 +5752,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_address"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97eed185ab09528f371dee1b6e00cdae2cb1dbd12d11f74a60cc35797b7310a3"
+checksum = "4c8dbd5739476254214f8077173df4a3cb532bb327c926d6f2be42831736ef2a"
 dependencies = [
  "bech32",
  "ootle_byte_type",
@@ -5767,9 +5767,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.28.4"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6de6a4586d77ff2b99d5558147906646366a24c8153f0742597006dc0b87df3"
+checksum = "6f0acfd34125628a4fb0a07b1cc4dd93919405efb58b10a253f956a5c3d8657a"
 dependencies = [
  "blake2",
  "borsh",
@@ -5815,9 +5815,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_metadata"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b30736577e4d734127722ee98bf4e9685a9e728b29939cc37f1212b790f833"
+checksum = "b915ce5c08363906a5fa7aca5506cbae443b19912e90cb514ecdf6d5457ec238"
 dependencies = [
  "borsh",
  "cargo_toml 0.22.3",
@@ -5832,9 +5832,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.28.4"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4792bd8bd6679a924826dea535ccfe944d096a02fff542e9cef8cb693df3c0b8"
+checksum = "65c7ea9f5ccdc2e2f5b1d1dddbea17d56f97de68b015d7276edfcdc92ca20bb4"
 dependencies = [
  "borsh",
  "hex",
@@ -5856,9 +5856,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.28.4"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633b6ba6de0a6ea2811158f0ae1797b53c2f49e5f75d2e64e240ef0343f575a9"
+checksum = "2dea250730b11f60cb7adeeb6fc6d872cde0d9b5ea1f23f4604b9b2b858e59a9"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -5883,9 +5883,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.28.4"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee70dc6f884d895c02379c027815938eec109fcfa064a50b387901b5ecfa7a7"
+checksum = "20d02268e2dcb8d3bd5ebfc4cc3ff2ddbdf0df5899f5ba292e14f972a0abc9f2"
 dependencies = [
  "anyhow",
  "digest 0.10.7",
@@ -5919,9 +5919,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.28.5"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09b478cea32fb526f6baca1d60345624733af58f8aa17407e775d6499988362"
+checksum = "4a3950d4443800453e770137c8feacf3b2fbe47af00d43130614268df36b385d"
 dependencies = [
  "hex",
  "ootle_serde",
@@ -5974,9 +5974,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.28.4"
+version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c2abe4d73542ea995550f678a1ac5cb9e8e89c5e1cf924309d4f16ed00e2c54"
+checksum = "1f077835bca221fca0223bab6f4872f48e36a90b5991517bc2523080a482222c"
 dependencies = [
  "anyhow",
  "tari_template_lib_types",
@@ -5984,9 +5984,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c8ffbf42d70c92a35a7a096615ebd4b48885f4b1f5083bfd3e322f20147e51"
+checksum = "fc17de601880593042b76e3765c04f3d92a83a1f3a3a6053d6cacacf8d68e67b"
 dependencies = [
  "borsh",
  "serde",
@@ -5998,9 +5998,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib_types"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502790d32b61f201ff7656767403407d207279ca8ae556f81e2326d1a0812fa0"
+checksum = "57e676bfffcab966319ce419099ba9f783d492910228291eebbebb62d4e2dd77"
 dependencies = [
  "bnum",
  "borsh",
@@ -6100,9 +6100,9 @@ dependencies = [
 
 [[package]]
 name = "thin-vec"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+checksum = "da322882471314edc77fa5232c587bcb87c9df52bfd0d7d4826f8868ead61899"
 
 [[package]]
 name = "thiserror"
@@ -6240,9 +6240,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -6394,9 +6394,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.10+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap 2.13.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -6887,12 +6887,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.246.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e1929aad146499e47362c876fcbcbb0363f730951d93438f511178626e999a8"
+checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.246.1",
+ "wasmparser 0.246.2",
 ]
 
 [[package]]
@@ -7096,9 +7096,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.246.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d991c35d79bf8336dc1cd632ed4aacf0dc5fac4bc466c670625b037b972bb9c"
+checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
 dependencies = [
  "bitflags 2.11.0",
  "indexmap 2.13.1",
@@ -7116,22 +7116,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "246.0.1"
+version = "246.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96cf2d50bc7478dcca61d00df4dadf922ef46c5924db20a97e6daaf09fe1cb09"
+checksum = "fe3fe8e3bf88ad96d031b4181ddbd64634b17cb0d06dfc3de589ef43591a9a62"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.2",
- "wasm-encoder 0.246.1",
+ "wasm-encoder 0.246.2",
 ]
 
 [[package]]
 name = "wat"
-version = "1.246.1"
+version = "1.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723f2473b47f738c12fc11c8e0bb8b27ce7cf9c78cf1a29dadbc2d34a2513292"
+checksum = "4bd7fda1199b94fff395c2d19a153f05dbe7807630316fa9673367666fd2ad8c"
 dependencies = [
  "wast",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5464,7 +5464,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tari-ootle-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "cargo-generate",
@@ -5795,7 +5795,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_publish_lib"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "hickory-proto",
  "ootle_serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ serde = { version = "1.0.215", features = ["derive"] }
 thiserror = "2.0.12"
 url = { version = "2.5.3", features = ["default", "serde"] }
 
-tari_ootle_walletd_client = "0.28"
+tari_ootle_walletd_client = "0.29"
 tari_engine = "0.28"
 tari_engine_types = "0.28"
 tari_ootle_common_types = "0.28"
-tari_template_lib_types = "0.23"
+tari_template_lib_types = "0.24"
 tari_ootle_template_metadata = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@ members = ["crates/publish_lib", "crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-cli"
 license = "BSD-3-Clause"
 
 [workspace.dependencies]
-tari_ootle_publish_lib = { path = "crates/publish_lib", version = "0.11" }
+tari_ootle_publish_lib = { path = "crates/publish_lib", version = "0.12" }
 
 tokio = { version = "1.41.1", features = ["full"] }
 serde = { version = "1.0.215", features = ["derive"] }

--- a/crates/cli/src/cli/commands/build.rs
+++ b/crates/cli/src/cli/commands/build.rs
@@ -1,14 +1,12 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use clap::Parser;
 
-use crate::cli::commands::publish::{build_template, find_target_dir};
+use crate::cli::commands::publish::{build_template, find_metadata_cbor};
 use crate::cli::util;
-
-const METADATA_CBOR_FILENAME: &str = "template_metadata.cbor";
 
 #[derive(Clone, Parser, Debug)]
 pub struct BuildArgs {
@@ -26,27 +24,8 @@ pub async fn handle(args: BuildArgs) -> anyhow::Result<()> {
 
     match find_metadata_cbor(&args.path).await {
         Ok(path) => println!("📄 Metadata:    {}", path.display()),
-        Err(_) => println!("📄 Metadata:    none"),
+        Err(e) => println!("📄 Metadata:    none ({e})"),
     }
 
     Ok(())
-}
-
-async fn find_metadata_cbor(project_dir: &Path) -> anyhow::Result<PathBuf> {
-    let target_dir = find_target_dir(project_dir).await?;
-    let build_dir = target_dir.join("wasm32-unknown-unknown").join("release").join("build");
-
-    if !build_dir.exists() {
-        anyhow::bail!("build directory not found");
-    }
-
-    for entry in std::fs::read_dir(&build_dir)? {
-        let entry = entry?;
-        let out_dir = entry.path().join("out").join(METADATA_CBOR_FILENAME);
-        if out_dir.exists() {
-            return Ok(out_dir);
-        }
-    }
-
-    anyhow::bail!("no metadata CBOR found")
 }

--- a/crates/cli/src/cli/commands/config.rs
+++ b/crates/cli/src/cli/commands/config.rs
@@ -93,9 +93,14 @@ async fn handle_show() -> anyhow::Result<()> {
 }
 
 /// Resolve where the config file should live:
-/// git repo root if in one, otherwise CWD.
+/// crate root (Cargo.toml) if in one, then git repo root, otherwise CWD.
 pub fn resolve_config_path() -> anyhow::Result<PathBuf> {
-    let root = find_repo_root().unwrap_or_else(|| std::env::current_dir().unwrap());
+    let cwd = std::env::current_dir()?;
+    let root = if cwd.join("Cargo.toml").exists() {
+        cwd
+    } else {
+        find_repo_root().unwrap_or(cwd)
+    };
     Ok(root.join(CONFIG_FILE_NAME))
 }
 

--- a/crates/cli/src/cli/commands/metadata/publish.rs
+++ b/crates/cli/src/cli/commands/metadata/publish.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 use anyhow::{Context, anyhow};
 use clap::Parser;
+use dialoguer::Confirm;
 use tari_engine_types::published_template::PublishedTemplateAddress;
 use tari_ootle_publish_lib::publisher::{SignedMetadataPayload, TemplatePublisher};
 use tari_ootle_template_metadata::TemplateMetadata;
@@ -28,8 +29,9 @@ pub struct PublishMetadataArgs {
     pub path: PathBuf,
 
     /// Template address to publish metadata for (e.g. template_bce07f... or raw hex).
+    /// If omitted, uses the address saved in tari.config.toml from the last publish.
     #[arg(long, short = 't')]
-    pub template_address: PublishedTemplateAddress,
+    pub template_address: Option<PublishedTemplateAddress>,
 
     /// Metadata server URL. Overrides the value in tari.config.toml and global CLI config.
     #[arg(long)]
@@ -59,7 +61,7 @@ pub struct PublishMetadataArgs {
 
 pub async fn handle(config: Config, args: PublishMetadataArgs) -> anyhow::Result<()> {
     let cbor_path = find_metadata_cbor(&args.path).await?;
-    let cbor_bytes = std::fs::read(&cbor_path).context("reading metadata CBOR file")?;
+    let mut cbor_bytes = std::fs::read(&cbor_path).context("reading metadata CBOR file")?;
 
     let url_override = args.wallet_daemon_url.as_ref().or(config.wallet_daemon_url.as_ref());
     let project_config = load_project_config(&args.path, url_override).await?;
@@ -73,14 +75,49 @@ pub async fn handle(config: Config, args: PublishMetadataArgs) -> anyhow::Result
         .or(config.metadata_server_url.as_ref())
         .unwrap_or(&default_url);
 
-    let metadata =
+    let mut metadata =
         TemplateMetadata::from_cbor(&cbor_bytes).context("metadata CBOR is invalid — cannot publish corrupt data")?;
-    println!(
-        "📄 Publishing metadata for {} v{} to {}",
-        metadata.name, metadata.version, metadata_server_url
-    );
 
-    let addr = args.template_address;
+    // Check if built metadata matches Cargo.toml
+    let cargo_toml_path = args.path.join("Cargo.toml");
+    if cargo_toml_path.exists() {
+        match tari_ootle_template_metadata::from_cargo_toml(&cargo_toml_path) {
+            Ok(current) if current != metadata => {
+                println!("⚠️  Built metadata does not match Cargo.toml (metadata may be stale)");
+                let rebuild = Confirm::new()
+                    .with_prompt("Rebuild to update metadata?")
+                    .default(true)
+                    .interact()?;
+                if rebuild {
+                    crate::cli::commands::publish::build_template(&args.path).await?;
+                    let new_cbor_path = find_metadata_cbor(&args.path).await?;
+                    cbor_bytes = std::fs::read(&new_cbor_path).context("reading rebuilt metadata CBOR")?;
+                    metadata = TemplateMetadata::from_cbor(&cbor_bytes).context("rebuilt metadata CBOR is invalid")?;
+                    println!("✅ Metadata rebuilt");
+                }
+            },
+            Ok(_) => {},
+            Err(e) => {
+                println!("⚠️  Could not read Cargo.toml metadata for freshness check: {e}");
+            },
+        }
+    }
+
+    // Resolve template address: CLI flag > project config
+    let addr = args
+        .template_address
+        .or_else(|| project_config.template_address().cloned())
+        .ok_or_else(|| {
+            anyhow!(
+                "No template address provided. Use --template-address or publish the template first \
+                 (`tari publish`) to save the address in tari.config.toml."
+            )
+        })?;
+
+    println!(
+        "📄 Publishing metadata for {} v{} to {} (template: {})",
+        metadata.name, metadata.version, metadata_server_url, addr
+    );
 
     if args.signed {
         let publisher = TemplatePublisher::new(project_config.network().clone());
@@ -197,5 +234,3 @@ pub async fn publish_metadata_signed(
 
     unreachable!()
 }
-
-

--- a/crates/cli/src/cli/commands/metadata/publish.rs
+++ b/crates/cli/src/cli/commands/metadata/publish.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::{Context, anyhow};
@@ -11,11 +11,10 @@ use tari_ootle_publish_lib::publisher::{SignedMetadataPayload, TemplatePublisher
 use tari_ootle_template_metadata::TemplateMetadata;
 use url::Url;
 
-use crate::cli::commands::publish::load_project_config;
+use crate::cli::commands::publish::{find_metadata_cbor, load_project_config};
 use crate::cli::config::Config;
 
 const DEFAULT_METADATA_SERVER: &str = "http://localhost:3000";
-const METADATA_CBOR_FILENAME: &str = "template_metadata.cbor";
 
 /// Default retry settings: 6 attempts, 10s initial backoff (10, 20, 40, 80, 160s ≈ ~5 min total).
 const DEFAULT_MAX_RETRIES: u32 = 6;
@@ -199,28 +198,4 @@ pub async fn publish_metadata_signed(
     unreachable!()
 }
 
-async fn find_metadata_cbor(crate_dir: &Path) -> anyhow::Result<PathBuf> {
-    let target_dir = crate::cli::commands::publish::find_target_dir(crate_dir).await?;
-    let build_dir = target_dir.join("wasm32-unknown-unknown").join("release").join("build");
 
-    if !build_dir.exists() {
-        return Err(anyhow!(
-            "Build output directory not found at {}. Run `tari build` first.",
-            build_dir.display()
-        ));
-    }
-
-    for entry in std::fs::read_dir(&build_dir).context("reading build directory")? {
-        let entry = entry?;
-        let out_file = entry.path().join("out").join(METADATA_CBOR_FILENAME);
-        if out_file.exists() {
-            return Ok(out_file);
-        }
-    }
-
-    Err(anyhow!(
-        "No {METADATA_CBOR_FILENAME} found in build output. \
-         Make sure the template uses tari_ootle_template_build in build.rs \
-         and has been built with `tari build`."
-    ))
-}

--- a/crates/cli/src/cli/commands/publish.rs
+++ b/crates/cli/src/cli/commands/publish.rs
@@ -162,6 +162,43 @@ pub async fn find_target_dir(dir: &Path) -> anyhow::Result<PathBuf> {
         .ok_or_else(|| anyhow!("cargo metadata missing target_directory"))
 }
 
+const METADATA_CBOR_FILENAME: &str = "template_metadata.cbor";
+
+/// Find the most recently generated metadata CBOR file in the build output.
+pub async fn find_metadata_cbor(project_dir: &Path) -> anyhow::Result<PathBuf> {
+    let target_dir = find_target_dir(project_dir).await?;
+    let build_dir = target_dir.join("wasm32-unknown-unknown").join("release").join("build");
+
+    if !build_dir.exists() {
+        return Err(anyhow!(
+            "Build output directory not found at {}. Run `tari build` first.",
+            build_dir.display()
+        ));
+    }
+
+    let mut newest: Option<(PathBuf, std::time::SystemTime)> = None;
+    for entry in std::fs::read_dir(&build_dir).context("reading build directory")? {
+        let entry = entry?;
+        let out_file = entry.path().join("out").join(METADATA_CBOR_FILENAME);
+        if out_file.exists() {
+            let modified = std::fs::metadata(&out_file)
+                .and_then(|m| m.modified())
+                .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+            if newest.as_ref().map_or(true, |(_, t)| modified > *t) {
+                newest = Some((out_file, modified));
+            }
+        }
+    }
+
+    newest
+        .map(|(path, _)| path)
+        .ok_or_else(|| anyhow!(
+            "No {METADATA_CBOR_FILENAME} found in build output. \
+             Make sure the template uses tari_ootle_template_build in build.rs \
+             and has been built with `tari build`."
+        ))
+}
+
 pub async fn load_project_config(
     project_folder: &Path,
     wallet_daemon_url_override: Option<&url::Url>,

--- a/crates/cli/src/cli/commands/publish.rs
+++ b/crates/cli/src/cli/commands/publish.rs
@@ -184,7 +184,7 @@ pub async fn find_metadata_cbor(project_dir: &Path) -> anyhow::Result<PathBuf> {
             let modified = std::fs::metadata(&out_file)
                 .and_then(|m| m.modified())
                 .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-            if newest.as_ref().map_or(true, |(_, t)| modified > *t) {
+            if newest.as_ref().is_none_or(|(_, t)| modified > *t) {
                 newest = Some((out_file, modified));
             }
         }

--- a/crates/cli/src/cli/commands/publish.rs
+++ b/crates/cli/src/cli/commands/publish.rs
@@ -190,13 +190,13 @@ pub async fn find_metadata_cbor(project_dir: &Path) -> anyhow::Result<PathBuf> {
         }
     }
 
-    newest
-        .map(|(path, _)| path)
-        .ok_or_else(|| anyhow!(
+    newest.map(|(path, _)| path).ok_or_else(|| {
+        anyhow!(
             "No {METADATA_CBOR_FILENAME} found in build output. \
              Make sure the template uses tari_ootle_template_build in build.rs \
              and has been built with `tari build`."
-        ))
+        )
+    })
 }
 
 pub async fn load_project_config(

--- a/crates/cli/src/cli/commands/template/inspect_metadata.rs
+++ b/crates/cli/src/cli/commands/template/inspect_metadata.rs
@@ -2,13 +2,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use std::io::BufReader;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::{Context, anyhow};
 use clap::Parser;
 use tari_ootle_template_metadata::TemplateMetadata;
-
-const METADATA_CBOR_FILENAME: &str = "template_metadata.cbor";
 
 #[derive(Clone, Parser, Debug)]
 pub struct InspectMetadataArgs {
@@ -29,7 +27,7 @@ pub struct InspectMetadataArgs {
 pub async fn handle(args: InspectMetadataArgs) -> anyhow::Result<()> {
     let cbor_path = match args.path {
         Some(p) => p,
-        None => find_metadata_cbor(&args.project_dir).await?,
+        None => crate::cli::commands::publish::find_metadata_cbor(&args.project_dir).await?,
     };
 
     if !cbor_path.exists() {
@@ -54,32 +52,6 @@ pub async fn handle(args: InspectMetadataArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn find_metadata_cbor(project_dir: &Path) -> anyhow::Result<PathBuf> {
-    let target_dir = crate::cli::commands::publish::find_target_dir(project_dir).await?;
-    let build_dir = target_dir.join("wasm32-unknown-unknown").join("release").join("build");
-
-    if !build_dir.exists() {
-        return Err(anyhow!(
-            "Build output directory not found at {}. Run `tari build` first.",
-            build_dir.display()
-        ));
-    }
-
-    // Search build output directories for the metadata CBOR file
-    for entry in std::fs::read_dir(&build_dir).context("reading build directory")? {
-        let entry = entry?;
-        let out_dir = entry.path().join("out").join(METADATA_CBOR_FILENAME);
-        if out_dir.exists() {
-            return Ok(out_dir);
-        }
-    }
-
-    Err(anyhow!(
-        "No {METADATA_CBOR_FILENAME} found in build output. \
-         Make sure the template uses tari_ootle_template_build in build.rs \
-         and has been built with `cargo build --target wasm32-unknown-unknown --release`."
-    ))
-}
 
 fn print_metadata_table(metadata: &TemplateMetadata, hash: &tari_ootle_template_metadata::MetadataHash) {
     println!();

--- a/crates/cli/src/cli/commands/template/inspect_metadata.rs
+++ b/crates/cli/src/cli/commands/template/inspect_metadata.rs
@@ -1,12 +1,14 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use std::io::BufReader;
 use std::path::PathBuf;
 
 use anyhow::{Context, anyhow};
 use clap::Parser;
+use dialoguer::Confirm;
 use tari_ootle_template_metadata::TemplateMetadata;
+
+use crate::cli::commands::publish::{build_template, find_metadata_cbor};
 
 #[derive(Clone, Parser, Debug)]
 pub struct InspectMetadataArgs {
@@ -27,7 +29,7 @@ pub struct InspectMetadataArgs {
 pub async fn handle(args: InspectMetadataArgs) -> anyhow::Result<()> {
     let cbor_path = match args.path {
         Some(p) => p,
-        None => crate::cli::commands::publish::find_metadata_cbor(&args.project_dir).await?,
+        None => find_metadata_cbor(&args.project_dir).await?,
     };
 
     if !cbor_path.exists() {
@@ -36,9 +38,36 @@ pub async fn handle(args: InspectMetadataArgs) -> anyhow::Result<()> {
 
     println!("📄 Reading metadata from {}", cbor_path.display());
 
-    let file = std::fs::File::open(&cbor_path).context("opening metadata CBOR file")?;
-    let reader = BufReader::new(file);
-    let metadata = TemplateMetadata::read_cbor_from(reader).context("decoding metadata CBOR")?;
+    let mut cbor_bytes = std::fs::read(&cbor_path).context("reading metadata CBOR file")?;
+    let mut metadata =
+        TemplateMetadata::from_cbor(&cbor_bytes).context("decoding metadata CBOR")?;
+
+    // Check if built metadata matches Cargo.toml
+    let cargo_toml_path = args.project_dir.join("Cargo.toml");
+    if cargo_toml_path.exists() {
+        match tari_ootle_template_metadata::from_cargo_toml(&cargo_toml_path) {
+            Ok(current) if current != metadata => {
+                println!("⚠️  Built metadata does not match Cargo.toml (metadata may be stale)");
+                let rebuild = Confirm::new()
+                    .with_prompt("Rebuild to update metadata?")
+                    .default(true)
+                    .interact()?;
+                if rebuild {
+                    build_template(&args.project_dir).await?;
+                    let new_cbor_path = find_metadata_cbor(&args.project_dir).await?;
+                    cbor_bytes = std::fs::read(&new_cbor_path).context("reading rebuilt metadata CBOR")?;
+                    metadata = TemplateMetadata::from_cbor(&cbor_bytes)
+                        .context("rebuilt metadata CBOR is invalid")?;
+                    println!("✅ Metadata rebuilt");
+                }
+            },
+            Ok(_) => {},
+            Err(e) => {
+                println!("⚠️  Could not read Cargo.toml metadata for freshness check: {e}");
+            },
+        }
+    }
+
     let hash = metadata.hash().context("computing metadata hash")?;
 
     if args.json {

--- a/crates/cli/src/cli/commands/template/inspect_metadata.rs
+++ b/crates/cli/src/cli/commands/template/inspect_metadata.rs
@@ -52,7 +52,6 @@ pub async fn handle(args: InspectMetadataArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-
 fn print_metadata_table(metadata: &TemplateMetadata, hash: &tari_ootle_template_metadata::MetadataHash) {
     println!();
     println!("  Name:           {}", metadata.name);

--- a/crates/cli/src/cli/commands/template/inspect_metadata.rs
+++ b/crates/cli/src/cli/commands/template/inspect_metadata.rs
@@ -39,8 +39,7 @@ pub async fn handle(args: InspectMetadataArgs) -> anyhow::Result<()> {
     println!("📄 Reading metadata from {}", cbor_path.display());
 
     let mut cbor_bytes = std::fs::read(&cbor_path).context("reading metadata CBOR file")?;
-    let mut metadata =
-        TemplateMetadata::from_cbor(&cbor_bytes).context("decoding metadata CBOR")?;
+    let mut metadata = TemplateMetadata::from_cbor(&cbor_bytes).context("decoding metadata CBOR")?;
 
     // Check if built metadata matches Cargo.toml
     let cargo_toml_path = args.project_dir.join("Cargo.toml");
@@ -56,8 +55,7 @@ pub async fn handle(args: InspectMetadataArgs) -> anyhow::Result<()> {
                     build_template(&args.project_dir).await?;
                     let new_cbor_path = find_metadata_cbor(&args.project_dir).await?;
                     cbor_bytes = std::fs::read(&new_cbor_path).context("reading rebuilt metadata CBOR")?;
-                    metadata = TemplateMetadata::from_cbor(&cbor_bytes)
-                        .context("rebuilt metadata CBOR is invalid")?;
+                    metadata = TemplateMetadata::from_cbor(&cbor_bytes).context("rebuilt metadata CBOR is invalid")?;
                     println!("✅ Metadata rebuilt");
                 }
             },

--- a/crates/cli/src/cli/commands/template/publish.rs
+++ b/crates/cli/src/cli/commands/template/publish.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use std::io::BufReader;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::{Context, anyhow};
 use clap::Parser;
@@ -13,13 +13,12 @@ use tari_ootle_publish_lib::walletd_client::ComponentAddressOrName;
 use tari_ootle_template_metadata::TemplateMetadata;
 
 use crate::cli::commands::metadata::publish::publish_metadata_to_server;
-use crate::cli::commands::publish::{build_template, load_project_config};
+use crate::cli::commands::publish::{build_template, find_metadata_cbor, load_project_config};
 use crate::cli::config::Config;
 use crate::cli::util;
 use crate::loading;
 
 const MAX_WASM_SIZE: usize = 5 * 1000 * 1000; // 5 MB
-const METADATA_CBOR_FILENAME: &str = "template_metadata.cbor";
 
 #[derive(Clone, Parser, Debug)]
 pub struct TemplatePublishArgs {
@@ -183,32 +182,6 @@ pub async fn handle(config: Config, mut args: TemplatePublishArgs) -> anyhow::Re
     }
 
     Ok(())
-}
-
-async fn find_metadata_cbor(crate_dir: &Path) -> anyhow::Result<PathBuf> {
-    let target_dir = crate::cli::commands::publish::find_target_dir(crate_dir).await?;
-    let build_dir = target_dir.join("wasm32-unknown-unknown").join("release").join("build");
-
-    if !build_dir.exists() {
-        return Err(anyhow!("build output directory not found at {}", build_dir.display()));
-    }
-
-    let mut found = Vec::new();
-    for entry in std::fs::read_dir(&build_dir).context("reading build directory")? {
-        let entry = entry?;
-        let out_file = entry.path().join("out").join(METADATA_CBOR_FILENAME);
-        if out_file.exists() {
-            found.push(out_file);
-        }
-    }
-
-    match found.len() {
-        0 => Err(anyhow!("no {METADATA_CBOR_FILENAME} in build output")),
-        1 => Ok(found.into_iter().next().unwrap()),
-        _ => Err(anyhow!(
-            "Multiple metadata files found. Specify the CBOR file path to `tari template inspect` instead."
-        )),
-    }
 }
 
 async fn resolve_account(

--- a/crates/cli/src/cli/commands/template/publish.rs
+++ b/crates/cli/src/cli/commands/template/publish.rs
@@ -70,9 +70,7 @@ pub async fn handle(config: Config, mut args: TemplatePublishArgs) -> anyhow::Re
 
     // Warn if template address already exists in config (republishing)
     if let Some(existing_addr) = project_config.template_address() {
-        println!(
-            "⚠️  A template has already been published from this project: {existing_addr}"
-        );
+        println!("⚠️  A template has already been published from this project: {existing_addr}");
         println!("   If the template binary is unchanged, the transaction will fail.");
         println!("   If changed, a new template address will be generated.");
         let proceed = Confirm::new()

--- a/crates/cli/src/cli/commands/template/publish.rs
+++ b/crates/cli/src/cli/commands/template/publish.rs
@@ -185,7 +185,18 @@ pub async fn handle(config: Config, mut args: TemplatePublishArgs) -> anyhow::Re
         println!("📝 Saved template address to {}", config_path.display());
     }
 
-    if args.publish_metadata && metadata_hash.is_some() {
+    let should_publish_metadata = if args.publish_metadata {
+        metadata_hash.is_some()
+    } else if metadata_hash.is_some() {
+        Confirm::new()
+            .with_prompt("Publish metadata to community server?")
+            .default(false)
+            .interact()?
+    } else {
+        false
+    };
+
+    if should_publish_metadata {
         let cbor_path = find_metadata_cbor(crate_dir).await?;
         let cbor_bytes = std::fs::read(&cbor_path).context("reading metadata CBOR for server publish")?;
 
@@ -207,8 +218,6 @@ pub async fn handle(config: Config, mut args: TemplatePublishArgs) -> anyhow::Re
                 );
             },
         }
-    } else if args.publish_metadata && metadata_hash.is_none() {
-        println!("⚠️  --publish-metadata was set but no metadata was found, skipping");
     }
 
     Ok(())

--- a/crates/cli/src/cli/commands/template/publish.rs
+++ b/crates/cli/src/cli/commands/template/publish.rs
@@ -68,6 +68,22 @@ pub async fn handle(config: Config, mut args: TemplatePublishArgs) -> anyhow::Re
     let url_override = args.wallet_daemon_url.as_ref().or(config.wallet_daemon_url.as_ref());
     let project_config = load_project_config(crate_dir, url_override).await?;
 
+    // Warn if template address already exists in config (republishing)
+    if let Some(existing_addr) = project_config.template_address() {
+        println!(
+            "⚠️  A template has already been published from this project: {existing_addr}"
+        );
+        println!("   If the template binary is unchanged, the transaction will fail.");
+        println!("   If changed, a new template address will be generated.");
+        let proceed = Confirm::new()
+            .with_prompt("Continue with publish?")
+            .default(false)
+            .interact()?;
+        if !proceed {
+            return Err(anyhow!("Publishing aborted"));
+        }
+    }
+
     // Build or use provided binary
     let template_bin = match args.binary.take() {
         Some(bin_path) => {

--- a/crates/cli/src/cli/commands/template/publish.rs
+++ b/crates/cli/src/cli/commands/template/publish.rs
@@ -152,7 +152,22 @@ pub async fn handle(config: Config, mut args: TemplatePublishArgs) -> anyhow::Re
             .await
     )?;
 
-    println!("⭐ Your new template's address: {template_address}");
+    let published_addr = PublishedTemplateAddress::from_template_address(template_address);
+    println!("⭐ Your new template's address: {published_addr}");
+
+    // Save template address to project config
+    let config_path = crate::cli::commands::config::resolve_config_path()?;
+    if config_path.exists() {
+        let content = tokio::fs::read_to_string(&config_path)
+            .await
+            .context("reading config")?;
+        let mut doc = content.parse::<toml_edit::DocumentMut>().context("parsing config")?;
+        doc.insert("template-address", toml_edit::value(published_addr.to_string()));
+        tokio::fs::write(&config_path, doc.to_string())
+            .await
+            .context("writing config")?;
+        println!("📝 Saved template address to {}", config_path.display());
+    }
 
     if args.publish_metadata && metadata_hash.is_some() {
         let cbor_path = find_metadata_cbor(crate_dir).await?;
@@ -167,7 +182,6 @@ pub async fn handle(config: Config, mut args: TemplatePublishArgs) -> anyhow::Re
             .unwrap_or(&default_url);
 
         println!("📡 Publishing metadata to {metadata_server_url}...");
-        let published_addr = PublishedTemplateAddress::from_template_address(template_address);
         match publish_metadata_to_server(metadata_server_url, &published_addr, &cbor_bytes, 6).await {
             Ok(()) => {},
             Err(e) => {

--- a/crates/cli/src/cli/commands/template/publish.rs
+++ b/crates/cli/src/cli/commands/template/publish.rs
@@ -178,7 +178,7 @@ pub async fn handle(config: Config, mut args: TemplatePublishArgs) -> anyhow::Re
             .await
             .context("reading config")?;
         let mut doc = content.parse::<toml_edit::DocumentMut>().context("parsing config")?;
-        doc.insert("template-address", toml_edit::value(published_addr.to_string()));
+        doc.insert("template_address", toml_edit::value(published_addr.to_string()));
         tokio::fs::write(&config_path, doc.to_string())
             .await
             .context("writing config")?;

--- a/crates/cli/src/cli/commands/template/publish.rs
+++ b/crates/cli/src/cli/commands/template/publish.rs
@@ -176,11 +176,16 @@ pub async fn handle(config: Config, mut args: TemplatePublishArgs) -> anyhow::Re
             .await
             .context("reading config")?;
         let mut doc = content.parse::<toml_edit::DocumentMut>().context("parsing config")?;
-        doc.insert("template_address", toml_edit::value(published_addr.to_string()));
+        doc.insert("template-address", toml_edit::value(published_addr.to_string()));
         tokio::fs::write(&config_path, doc.to_string())
             .await
             .context("writing config")?;
         println!("📝 Saved template address to {}", config_path.display());
+    } else {
+        println!(
+            "ℹ️  Config file not found at {}. Run `tari config init` to create one.",
+            config_path.display()
+        );
     }
 
     let should_publish_metadata = if args.publish_metadata {

--- a/crates/cli/src/project/config.rs
+++ b/crates/cli/src/project/config.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use serde::{Deserialize, Serialize};
+use tari_engine_types::published_template::PublishedTemplateAddress;
 use tari_ootle_publish_lib::NetworkConfig;
 use tari_ootle_publish_lib::walletd_client::ComponentAddressOrName;
 use url::Url;
@@ -13,6 +14,9 @@ pub struct ProjectConfig {
     default_account: Option<String>,
     /// Metadata server URL for publishing template metadata.
     metadata_server_url: Option<url::Url>,
+    /// Template address from the most recent publish.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    template_address: Option<PublishedTemplateAddress>,
 }
 
 impl ProjectConfig {
@@ -28,6 +32,10 @@ impl ProjectConfig {
         self.metadata_server_url.as_ref()
     }
 
+    pub fn template_address(&self) -> Option<&PublishedTemplateAddress> {
+        self.template_address.as_ref()
+    }
+
     pub fn parsed_default_account(&self) -> anyhow::Result<Option<ComponentAddressOrName>> {
         let acc = self.default_account.as_ref().map(|s| s.parse()).transpose()?;
         Ok(acc)
@@ -40,6 +48,7 @@ impl Default for ProjectConfig {
             network: NetworkConfig::new(Url::parse("http://127.0.0.1:9000/json_rpc").unwrap()),
             default_account: None,
             metadata_server_url: None,
+            template_address: None,
         }
     }
 }

--- a/crates/publish_lib/Cargo.toml
+++ b/crates/publish_lib/Cargo.toml
@@ -14,7 +14,7 @@ tari_engine = { workspace = true }
 tari_engine_types = { workspace = true }
 tari_template_lib_types = { workspace = true }
 tari_ootle_template_metadata = { workspace = true }
-tari_ootle_wallet_sdk = "0.28"
+tari_ootle_wallet_sdk = "0.28.6"
 ootle_serde = { version = "0.2", features = ["hex"] }
 
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }


### PR DESCRIPTION
## Summary
- **fix**: When multiple `template_metadata.cbor` files exist in build output (stale artifacts), pick the most recently modified instead of erroring with "Multiple metadata files found"
- **refactor**: Deduplicate `find_metadata_cbor` into a single shared function in `publish.rs`
- **fix**: Show error reason when metadata is not found in `tari build` output
- **feat**: Save template address to `tari.config.toml` after `tari publish`, so `tari metadata publish` can omit `--template-address`
- **feat**: `tari metadata publish` validates that built CBOR matches `Cargo.toml`; if stale, prompts to rebuild
- **fix**: `tari config init` creates config at crate root (Cargo.toml) if CWD is a crate, not git repo root
- **chore**: Bump workspace version to 0.12.0

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` — all 7 tests pass
- [x] `tari publish` saves template address to config
- [x] `tari metadata publish` works without `--template-address` after publish
- [x] `tari metadata publish` detects stale metadata and prompts to rebuild
- [x] Multiple stale CBOR files no longer cause errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)