### PR TITLE
feat: add init command, v0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@ members = ["crates/publish_lib", "crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-cli"
 license = "BSD-3-Clause"
 
 [workspace.dependencies]
-tari_ootle_publish_lib = { path = "crates/publish_lib", version = "0.13" }
+tari_ootle_publish_lib = { path = "crates/publish_lib", version = "0.14" }
 
 tokio = { version = "1.41.1", features = ["full"] }
 serde = { version = "1.0.215", features = ["derive"] }

--- a/crates/cli/src/cli/command.rs
+++ b/crates/cli/src/cli/command.rs
@@ -121,7 +121,7 @@ pub struct Cli {
 
 #[derive(Clone, Subcommand)]
 pub enum Command {
-    /// Initialise the project config and template build.rs in the current crate.
+    /// Initialise the project config and template metadata in a Tari template crate.
     Init {
         #[clap(flatten)]
         args: InitArgs,

--- a/crates/cli/src/cli/command.rs
+++ b/crates/cli/src/cli/command.rs
@@ -4,13 +4,14 @@
 use crate::cli::commands::build::BuildArgs;
 use crate::cli::commands::config::ConfigCommand;
 use crate::cli::commands::create::CreateArgs;
+use crate::cli::commands::init::InitArgs;
 use crate::cli::commands::metadata::MetadataCommand;
 use crate::cli::commands::publish;
 use crate::cli::commands::publish::PublishArgs;
 use crate::cli::commands::template::TemplateCommand;
 use crate::{
     cli::{
-        commands::{build, config as config_cmd, create, metadata, template, wizard},
+        commands::{build, config as config_cmd, create, init, metadata, template, wizard},
         config::{Config, TemplateRepository},
         util,
     },
@@ -120,6 +121,11 @@ pub struct Cli {
 
 #[derive(Clone, Subcommand)]
 pub enum Command {
+    /// Initialise the project config and template build.rs in the current crate.
+    Init {
+        #[clap(flatten)]
+        args: InitArgs,
+    },
     /// Create a new Tari template crate from a starter template.
     #[clap(alias = "new")]
     Create {
@@ -237,6 +243,10 @@ impl Cli {
         // Config command operates on project config, not CLI config
         if let Command::Config { command } = command {
             return config_cmd::handle(command).await;
+        }
+
+        if let Command::Init { args } = command {
+            return init::handle(args).await;
         }
 
         if let Command::Build { args } = command {

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -1,0 +1,23 @@
+// Copyright 2024 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use clap::Parser;
+
+use crate::cli::commands::config;
+use crate::cli::commands::template::init_metadata::{self, InitMetadataArgs};
+
+#[derive(Clone, Parser, Debug)]
+pub struct InitArgs {
+    #[clap(flatten)]
+    pub metadata_args: InitMetadataArgs,
+}
+
+pub async fn handle(args: InitArgs) -> anyhow::Result<()> {
+    // Init project config (tari.config.toml)
+    config::handle(config::ConfigCommand::Init).await?;
+
+    // Init template build.rs and metadata
+    init_metadata::handle(args.metadata_args).await?;
+
+    Ok(())
+}

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -1,10 +1,12 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use anyhow::Context;
 use clap::Parser;
+use tokio::fs;
 
-use crate::cli::commands::config;
 use crate::cli::commands::template::init_metadata::{self, InitMetadataArgs};
+use crate::project::{CONFIG_FILE_NAME, ProjectConfig};
 
 #[derive(Clone, Parser, Debug)]
 pub struct InitArgs {
@@ -13,8 +15,15 @@ pub struct InitArgs {
 }
 
 pub async fn handle(args: InitArgs) -> anyhow::Result<()> {
-    // Init project config (tari.config.toml)
-    config::handle(config::ConfigCommand::Init).await?;
+    // Init project config (tari.config.toml) in the target crate directory
+    let config_path = args.metadata_args.path.join(CONFIG_FILE_NAME);
+    if config_path.exists() {
+        println!("ℹ️  {} already exists at {}", CONFIG_FILE_NAME, config_path.display());
+    } else {
+        let default = toml::to_string_pretty(&ProjectConfig::default())?;
+        fs::write(&config_path, &default).await.context("writing config file")?;
+        println!("✅ Created {} at {}", CONFIG_FILE_NAME, config_path.display());
+    }
 
     // Init template build.rs and metadata
     init_metadata::handle(args.metadata_args).await?;

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -4,6 +4,7 @@
 pub mod build;
 pub mod config;
 pub mod create;
+pub mod init;
 pub mod metadata;
 pub mod publish;
 pub mod template;

--- a/docs/02-guides/project-configuration.md
+++ b/docs/02-guides/project-configuration.md
@@ -87,6 +87,27 @@ template-repo/
 
 ## Command-Line Arguments
 
+### `tari init` Options
+
+```bash
+tari init [OPTIONS] [PATH]
+
+Arguments:
+  [PATH]  Path to the template crate directory [default: .]
+
+Options:
+      --description <DESCRIPTION>      Template description
+      --tags <TAGS>                    Comma-separated tags
+      --category <CATEGORY>            Template category
+      --documentation <DOCUMENTATION>  Documentation URL
+      --homepage <HOMEPAGE>            Homepage URL
+      --logo-url <LOGO_URL>            Logo URL
+  -y, --non-interactive                Skip interactive prompts
+  -h, --help                           Print help
+```
+
+Combines `tari config init` (project config) and `tari template init` (build.rs and metadata) into a single command.
+
 ### `tari create` (alias `new`) Options
 
 <!-- SOURCE: crates/cli/src/cli/commands/create.rs:23-38 -->

--- a/docs/03-reference/cli-commands.md
+++ b/docs/03-reference/cli-commands.md
@@ -1,8 +1,8 @@
 ---
 title: CLI Commands Reference
 description: Complete reference for all Tari CLI commands, arguments, and options
-last_updated: 2026-04-07
-version: "0.11"
+last_updated: 2026-04-14
+version: "0.14"
 verified_against: crates/cli/src/cli/command.rs, command implementations
 audience: users
 ---
@@ -29,6 +29,7 @@ tari [GLOBAL_OPTIONS] <COMMAND> [COMMAND_OPTIONS]
 
 | Command | Alias | Purpose |
 |---------|-------|---------|
+| [`init`](#init) | | Initialise project config and template build.rs |
 | [`create`](#create) | `new` | Create a new template crate from a starter template |
 | [`build`](#build) | | Build the template WASM binary |
 | [`publish`](#publish) | `deploy` | Publish a template to the network |
@@ -36,6 +37,37 @@ tari [GLOBAL_OPTIONS] <COMMAND> [COMMAND_OPTIONS]
 | [`metadata`](#metadata) | | Metadata server operations (inspect, publish) |
 | [`config`](#config) | | Manage project configuration |
 | *(no command)* | | [Interactive setup wizard](#wizard) |
+
+---
+
+## `init`
+
+Initialises the project config (`tari.config.toml`) and template `build.rs` in a single step. Combines `tari config init` and `tari template init`.
+
+```bash
+tari init [OPTIONS] [PATH]
+```
+
+| Argument / Option | Type | Default | Description |
+|-------------------|------|---------|-------------|
+| `[PATH]` | Path | `.` | Path to the template crate directory (containing Cargo.toml) |
+| `--description` | String | *prompted if missing* | Template description (written to `[package].description`) |
+| `--tags` | String (comma-separated) | *prompted* | Tags (e.g. "token,fungible,defi") |
+| `--category` | String | *prompted* | Template category |
+| `--documentation` | String | *prompted* | Documentation URL |
+| `--homepage` | String | *prompted* | Homepage URL |
+| `--logo-url` | String | *prompted* | Logo URL |
+| `-y, --non-interactive` | Flag | `false` | Skip interactive prompts |
+
+### Example
+
+```bash
+# Interactive — prompts for metadata fields
+tari init
+
+# Non-interactive with metadata
+tari init -y --tags token,defi --category token
+```
 
 ---
 

--- a/docs/03-reference/configuration-schema.md
+++ b/docs/03-reference/configuration-schema.md
@@ -1,8 +1,8 @@
 ---
 title: Configuration Schema Reference
 description: Complete reference for all Tari CLI configuration options and file formats
-last_updated: 2026-04-07
-version: "0.11"
+last_updated: 2026-04-14
+version: "0.14"
 verified_against: crates/cli/src/cli/config.rs, crates/cli/src/project/config.rs
 audience: users
 ---
@@ -88,7 +88,7 @@ tari -e "wallet_daemon_url=http://localhost:12008/json_rpc" publish
 
 ### File Location
 
-`tari.config.toml` in the project root or git repository root. Created with `tari config init` or automatically by the wizard.
+`tari.config.toml` in the project root or git repository root. Created with `tari init`, `tari config init`, or automatically by the wizard.
 
 ### Schema
 
@@ -192,11 +192,14 @@ Arbitrary key-value pairs (string values only).
 ### Setting Up Metadata
 
 ```bash
-# Interactive setup (adds build.rs and Cargo.toml section)
+# One-step: initialise project config AND template metadata
+tari init
+
+# Or just template metadata
 tari template init
 
 # Non-interactive
-tari template init -y --tags token,defi --category token --logo-url https://example.com/logo.png
+tari init -y --tags token,defi --category token --logo-url https://example.com/logo.png
 ```
 
 ### Inspecting Metadata


### PR DESCRIPTION
## Summary
- Add `tari init` command that initialises both the project config (`tari.config.toml`) and the template `build.rs` / metadata in `Cargo.toml` in a single step
- Bump version to 0.14.0

## Test plan
- [ ] Run `tari init` in a template crate directory and verify both `tari.config.toml` and `build.rs` are created
- [ ] Run `tari init -y --tags token,defi` to verify non-interactive mode works
- [ ] Run `tari init` in a directory that already has both files and verify idempotent behavior
- [ ] Run `cargo build` after init to verify the generated `build.rs` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)