### PR TITLE
feat: update to template_metadata 0.5 with supersedes and commit_hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ buildtools/Output/
 clients/validator_node_grpc_client/package-lock.json
 /dan_layer/wallet/storage_sqlite/temp.sqlite
 /integration_tests/cucumber-output-junit.xml
+
+.claude/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -112,7 +112,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1624,7 +1624,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1779,7 +1779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1787,6 +1787,15 @@ name = "ethnum"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+
+[[package]]
+name = "faster-hex"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "faster-hex"
@@ -2221,11 +2230,22 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5eccc17194ed0e67d49285e4853307e4147e95407f91c1c3e4a13ba9f4e4ce"
+dependencies = [
+ "faster-hex 0.9.0",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-hash"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826036a9bee95945b0be1e2394c64cd4289916c34a639818f8fd5153906985c1"
 dependencies = [
- "faster-hex",
+ "faster-hex 0.10.0",
  "gix-features",
  "sha1-checked",
  "thiserror 2.0.18",
@@ -2237,7 +2257,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a27d4a3ea9640da504a2657fef3419c517fd71f1767ad8935298bcc805edd195"
 dependencies = [
- "gix-hash",
+ "gix-hash 0.20.1",
  "hashbrown 0.16.1",
  "parking_lot",
 ]
@@ -2263,7 +2283,7 @@ dependencies = [
  "gix-actor",
  "gix-date",
  "gix-features",
- "gix-hash",
+ "gix-hash 0.20.1",
  "gix-hashtable",
  "gix-path",
  "gix-utils",
@@ -2295,7 +2315,7 @@ dependencies = [
  "gix-actor",
  "gix-features",
  "gix-fs",
- "gix-hash",
+ "gix-hash 0.20.1",
  "gix-lock",
  "gix-object",
  "gix-path",
@@ -2659,7 +2679,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2947,7 +2967,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3695,8 +3715,6 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 [[package]]
 name = "ootle_byte_type"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45546b0e24eaeba4ec7991029fa74732141a3514d02164ea10dbb7ec71053ac"
 dependencies = [
  "tari_crypto",
  "tari_template_lib_types",
@@ -3705,10 +3723,19 @@ dependencies = [
 [[package]]
 name = "ootle_serde"
 version = "0.2.0"
+dependencies = [
+ "base64 0.22.1",
+ "hex",
+ "serde",
+ "tari_bor",
+]
+
+[[package]]
+name = "ootle_serde"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ebf90e42bffb2436ce6732a023b0cd48de62c981fcbfdef88fa4b3b7f31d867"
 dependencies = [
- "base64 0.22.1",
  "hex",
  "serde",
  "tari_bor",
@@ -4229,7 +4256,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4267,7 +4294,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4735,7 +4762,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4803,7 +4830,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5249,7 +5276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5487,8 +5514,6 @@ dependencies = [
 [[package]]
 name = "tari_bor"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a42eeda12c38655b5a348e0ab99370affc27477eadd6af0a6736374ecf0ef68"
 dependencies = [
  "borsh",
  "ciborium",
@@ -5520,8 +5545,7 @@ dependencies = [
 [[package]]
 name = "tari_common"
 version = "5.3.0-pre.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93db3110c7aeebcec04e9bcdcc2347588161af7aa4b24a628569d65cc8698d2"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.4#cd40a655abb117e43a87fcdbd9bb7d78f18cd6a3"
 dependencies = [
  "anyhow",
  "cargo_toml 0.20.5",
@@ -5544,8 +5568,7 @@ dependencies = [
 [[package]]
 name = "tari_common_types"
 version = "5.3.0-pre.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5411fe9a5dc17bb1395d8bb4b4f12dd36a7d23bfe78421ffb22ca20c5b9d6e5"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.4#cd40a655abb117e43a87fcdbd9bb7d78f18cd6a3"
 dependencies = [
  "argon2 0.4.1",
  "base64 0.22.1",
@@ -5570,7 +5593,7 @@ dependencies = [
  "subtle",
  "tari_common",
  "tari_crypto",
- "tari_hashing",
+ "tari_hashing 5.3.0-pre.4 (git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.4)",
  "tari_max_size",
  "tari_utilities",
  "thiserror 2.0.18",
@@ -5580,17 +5603,15 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.28.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701c634d2c98ea456f34cdaf682cd8f16e226ef689214eb5d293186c51fa187a"
+version = "0.28.10"
 dependencies = [
  "borsh",
- "ootle_serde",
+ "ootle_serde 0.2.0",
  "serde",
  "tari_common_types",
  "tari_crypto",
  "tari_engine_types",
- "tari_hashing",
+ "tari_hashing 5.3.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_common_types",
  "tari_sidechain",
  "tari_template_lib",
@@ -5621,9 +5642,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.28.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2531f5fc762f2401e8786430e81860895dd1671fe625fb90da6f522749e4171"
+version = "0.28.10"
 dependencies = [
  "blake2",
  "indexmap 2.13.1",
@@ -5648,9 +5667,7 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.28.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f30cd34e65d6461caa95b7eadff16dec2c5d5d0934d5a5034a7c18a0ecc45f"
+version = "0.28.10"
 dependencies = [
  "blake2",
  "borsh",
@@ -5661,13 +5678,13 @@ dependencies = [
  "lazy_static",
  "log",
  "ootle_byte_type",
- "ootle_serde",
+ "ootle_serde 0.2.0",
  "rand 0.8.5",
  "serde",
  "serde_json",
  "tari_bor",
  "tari_crypto",
- "tari_hashing",
+ "tari_hashing 5.3.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_template_metadata",
  "tari_template_abi",
  "tari_template_lib",
@@ -5677,8 +5694,7 @@ dependencies = [
 [[package]]
 name = "tari_features"
 version = "5.3.0-pre.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0afade94aee8a493a0adf05421887e343f828cb98da72375a82d16ee18d8207"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.4#cd40a655abb117e43a87fcdbd9bb7d78f18cd6a3"
 
 [[package]]
 name = "tari_hashing"
@@ -5693,10 +5709,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tari_hashing"
+version = "5.3.0-pre.4"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.4#cd40a655abb117e43a87fcdbd9bb7d78f18cd6a3"
+dependencies = [
+ "blake2",
+ "borsh",
+ "digest 0.10.7",
+ "tari_crypto",
+]
+
+[[package]]
 name = "tari_indexer_client"
-version = "0.28.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3919462b04010934ac577c15e876f0a857f7b93fc8737be158ddcee1995de2c5"
+version = "0.28.10"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -5719,23 +5744,21 @@ dependencies = [
 [[package]]
 name = "tari_jellyfish"
 version = "5.3.0-pre.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdce30c894056fa09b5dc08f8539ac1ae79de5ce80d88ebbc502ba2717790c3a"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.4#cd40a655abb117e43a87fcdbd9bb7d78f18cd6a3"
 dependencies = [
  "borsh",
  "digest 0.10.7",
  "indexmap 2.13.1",
  "serde",
  "tari_crypto",
- "tari_hashing",
+ "tari_hashing 5.3.0-pre.4 (git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.4)",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "tari_max_size"
 version = "5.3.0-pre.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e59f86210c10d10cb5fa1d20b02b00c01af659a43485f3f6136b2dd6295d109"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.4#cd40a655abb117e43a87fcdbd9bb7d78f18cd6a3"
 dependencies = [
  "borsh",
  "serde",
@@ -5746,8 +5769,6 @@ dependencies = [
 [[package]]
 name = "tari_ootle_address"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8dbd5739476254214f8077173df4a3cb532bb327c926d6f2be42831736ef2a"
 dependencies = [
  "bech32",
  "ootle_byte_type",
@@ -5760,9 +5781,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.28.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0acfd34125628a4fb0a07b1cc4dd93919405efb58b10a253f956a5c3d8657a"
+version = "0.28.10"
 dependencies = [
  "blake2",
  "borsh",
@@ -5772,7 +5791,7 @@ dependencies = [
  "indexmap 2.13.1",
  "newtype-ops",
  "ootle_byte_type",
- "ootle_serde",
+ "ootle_serde 0.2.0",
  "prost 0.14.3",
  "prost-types",
  "rand 0.8.5",
@@ -5780,7 +5799,7 @@ dependencies = [
  "tari_bor",
  "tari_crypto",
  "tari_engine_types",
- "tari_hashing",
+ "tari_hashing 5.3.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_template_metadata",
  "tari_template_lib_types",
  "thiserror 2.0.18",
@@ -5791,7 +5810,7 @@ name = "tari_ootle_publish_lib"
 version = "0.14.0"
 dependencies = [
  "hickory-proto",
- "ootle_serde",
+ "ootle_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "tari_engine",
  "tari_engine_types",
@@ -5808,39 +5827,38 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_metadata"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b915ce5c08363906a5fa7aca5506cbae443b19912e90cb514ecdf6d5457ec238"
+version = "0.5.0"
 dependencies = [
  "borsh",
  "cargo_toml 0.22.3",
+ "gix-hash 0.15.1",
  "hex",
  "multihash 0.19.3",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "tari_bor",
+ "tari_template_lib_types",
  "thiserror 2.0.18",
+ "url",
 ]
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.28.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c7ea9f5ccdc2e2f5b1d1dddbea17d56f97de68b015d7276edfcdc92ca20bb4"
+version = "0.28.10"
 dependencies = [
  "borsh",
  "hex",
  "indexmap 2.13.1",
  "log",
  "ootle_byte_type",
- "ootle_serde",
+ "ootle_serde 0.2.0",
  "rand 0.8.5",
  "serde",
  "tari_bor",
  "tari_crypto",
  "tari_engine_types",
- "tari_hashing",
+ "tari_hashing 5.3.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_common_types",
  "tari_ootle_template_metadata",
  "tari_template_lib_types",
@@ -5849,9 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.28.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dea250730b11f60cb7adeeb6fc6d872cde0d9b5ea1f23f4604b9b2b858e59a9"
+version = "0.28.10"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -5866,7 +5882,7 @@ dependencies = [
  "subtle",
  "tari_crypto",
  "tari_engine_types",
- "tari_hashing",
+ "tari_hashing 5.3.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tari_ootle_common_types",
  "tari_template_lib_types",
  "tari_utilities",
@@ -5876,9 +5892,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.28.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d02268e2dcb8d3bd5ebfc4cc3ff2ddbdf0df5899f5ba292e14f972a0abc9f2"
+version = "0.28.10"
 dependencies = [
  "anyhow",
  "digest 0.10.7",
@@ -5886,7 +5900,7 @@ dependencies = [
  "keyring",
  "log",
  "ootle_byte_type",
- "ootle_serde",
+ "ootle_serde 0.2.0",
  "passwords",
  "rand 0.8.5",
  "serde",
@@ -5912,12 +5926,10 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3950d4443800453e770137c8feacf3b2fbe47af00d43130614268df36b385d"
+version = "0.29.2"
 dependencies = [
  "hex",
- "ootle_serde",
+ "ootle_serde 0.2.0",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
@@ -5939,8 +5951,7 @@ dependencies = [
 [[package]]
 name = "tari_sidechain"
 version = "5.3.0-pre.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f00dde62f5cb92d09a24c0124b8c11fb41727e0acb62427540ea42da94f1efe"
+source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.4#cd40a655abb117e43a87fcdbd9bb7d78f18cd6a3"
 dependencies = [
  "borsh",
  "hex",
@@ -5948,7 +5959,7 @@ dependencies = [
  "serde",
  "tari_common_types",
  "tari_crypto",
- "tari_hashing",
+ "tari_hashing 5.3.0-pre.4 (git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.4)",
  "tari_jellyfish",
  "tari_utilities",
  "thiserror 2.0.18",
@@ -5957,8 +5968,6 @@ dependencies = [
 [[package]]
 name = "tari_template_abi"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bdb2b66b9db191152ec10f637657cd20f27151576f059fb215409ca09c10d93"
 dependencies = [
  "serde",
  "tari_bor",
@@ -5967,9 +5976,7 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.28.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f077835bca221fca0223bab6f4872f48e36a90b5991517bc2523080a482222c"
+version = "0.28.10"
 dependencies = [
  "anyhow",
  "tari_template_lib_types",
@@ -5978,8 +5985,6 @@ dependencies = [
 [[package]]
 name = "tari_template_lib"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc17de601880593042b76e3765c04f3d92a83a1f3a3a6053d6cacacf8d68e67b"
 dependencies = [
  "borsh",
  "serde",
@@ -5992,8 +5997,6 @@ dependencies = [
 [[package]]
 name = "tari_template_lib_types"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e676bfffcab966319ce419099ba9f783d492910228291eebbebb62d4e2dd77"
 dependencies = [
  "bnum",
  "borsh",
@@ -6006,8 +6009,6 @@ dependencies = [
 [[package]]
 name = "tari_template_macros"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4280c01eff9d0ba0e302a41c2f5b59c214bde5a8bc63a9b3881750ac6c1843d6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6040,10 +6041,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6079,7 +6080,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7260,7 +7261,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7812,3 +7813,7 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[patch.unused]]
+name = "tari_ootle_template_build"
+version = "0.5.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]
@@ -283,9 +283,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -366,6 +366,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
+name = "base256emoji"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e9430d9a245a77c92176e649af6e275f20839a48389859d1661e9a128d077c"
+dependencies = [
+ "const-str",
+ "match-lookup",
+]
+
+[[package]]
 name = "base58-monero"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,7 +443,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -449,9 +465,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -513,7 +529,7 @@ dependencies = [
  "borsh-derive",
  "bytes",
  "cfg_aliases",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -523,7 +539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
 dependencies = [
  "once_cell",
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -538,12 +554,6 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
 ]
-
-[[package]]
-name = "bs58"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bs58"
@@ -641,7 +651,7 @@ dependencies = [
  "heck 0.5.0",
  "home",
  "ignore",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "indicatif",
  "liquid",
  "liquid-core",
@@ -701,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -970,12 +980,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_format"
-version = "0.2.35"
+name = "const-str"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -1072,13 +1089,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "corosensei"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,18 +1121,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.129.1"
+version = "0.129.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40630d663279bc855bff805d6f5e8a0b6a1867f9df95b010511ac6dc894e9395"
+checksum = "4b242b4c3675139f52f0b55624fb92571551a344305c5998f55ad20fa527bc55"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.129.1"
+version = "0.129.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee6aec5ceb55e5fdbcf7ef677d7c7195531360ff181ce39b2b31df11d57305f"
+checksum = "499715f19799219f32641b14f2a162f91e50bc1b61c2d2184c2be971716f5c56"
 dependencies = [
  "cranelift-srcgen",
 ]
@@ -1174,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.129.1"
+version = "0.129.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235da0e52ee3a0052d0e944c3470ff025b1f4234f6ec4089d3109f2d2ffa6cbd"
+checksum = "483b2c94a1b7f6fba0714387ba34ca56d114b2214a80be018acbb2ed40e09a1e"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1186,15 +1196,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.129.1"
+version = "0.129.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c07c6c440bd1bf920ff7597a1e743ede1f68dcd400730bd6d389effa7662af"
+checksum = "c4aae718c336a52d90d4ebe9a2d8c3cf0906a4bee78f0e6867e777eebbe554fe"
 
 [[package]]
 name = "cranelift-control"
-version = "0.129.1"
+version = "0.129.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8797c022e02521901e1aee483dea3ed3c67f2bf0a26405c9dd48e8ee7a70944b"
+checksum = "a18e94519070dc56cddb71906a08cea6a28a1d7c58ed501b88f273fa6b45fa07"
 dependencies = [
  "arbitrary",
 ]
@@ -1229,9 +1239,9 @@ checksum = "524d804c1ebd8c542e6f64e71aa36934cec17c5da4a9ae3799796220317f5d23"
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.129.1"
+version = "0.129.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d953932541249c91e3fa70a75ff1e52adc62979a2a8132145d4b9b3e6d1a9b6a"
+checksum = "4a1a001a9dc4557d9e2be324bc932621c0aa9bf33b74dfefa2338f0bf8913329"
 
 [[package]]
 name = "crc32fast"
@@ -1336,7 +1346,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -1474,6 +1484,26 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8142a83c17aa9461d637e649271eae18bf2edd00e91f2e105df36c3c16355bdb"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
+dependencies = [
+ "data-encoding",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "dbus"
@@ -1851,7 +1881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hex",
  "static_assertions",
 ]
@@ -2107,7 +2137,7 @@ checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "stable_deref_trait",
 ]
 
@@ -2117,7 +2147,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -2166,7 +2196,7 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c489abb061c74b0c3ad790e24a606ef968cebab48ec673d6a891ece7d5aef64"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bstr",
  "gix-path",
  "libc",
@@ -2220,7 +2250,7 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74254992150b0a88fdb3ad47635ab649512dff2cbbefca7916bb459894fc9d56"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bstr",
  "gix-features",
  "gix-path",
@@ -2331,7 +2361,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea9962ed6d9114f7f100efe038752f41283c225bb507a2888903ac593dffa6be"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "gix-path",
  "libc",
  "windows-sys 0.61.2",
@@ -2417,7 +2447,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2473,6 +2503,12 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heapless"
@@ -2531,6 +2567,24 @@ dependencies = [
  "tinyvec",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2632,15 +2686,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2857,12 +2910,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -3080,9 +3133,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3113,6 +3166,21 @@ dependencies = [
  "windows-sys 0.60.2",
  "zeroize",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kstring"
@@ -3167,9 +3235,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libdbus-sys"
@@ -3211,15 +3279,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libredox"
-version = "0.1.15"
+name = "libp2p-identity"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "f0c7892c221730ba55f7196e98b0b8ba5e04b4155651736036628e9f73ed6fc3"
 dependencies = [
- "bitflags 2.11.0",
+ "bs58",
+ "hkdf",
+ "multihash",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -3404,6 +3486,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "match-lookup"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3511,31 +3604,33 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "multiaddr"
-version = "0.14.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c580bfdd8803cce319b047d239559a22f809094aaea4ac13902a1fdcfcd4261"
+checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
 dependencies = [
  "arrayref",
- "bs58 0.4.0",
  "byteorder",
  "data-encoding",
- "multihash 0.16.3",
+ "libp2p-identity",
+ "multibase",
+ "multihash",
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint 0.7.2",
+ "unsigned-varint",
  "url",
 ]
 
 [[package]]
-name = "multihash"
-version = "0.16.3"
+name = "multibase"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
+checksum = "8694bb4835f452b0e3bb06dbebb1d6fc5385b6ca1caf2e55fd165c042390ec77"
 dependencies = [
- "core2",
- "multihash-derive",
- "unsigned-varint 0.7.2",
+ "base-x",
+ "base256emoji",
+ "data-encoding",
+ "data-encoding-macro",
 ]
 
 [[package]]
@@ -3545,21 +3640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ace881e3f514092ce9efbcb8f413d0ad9763860b828981c2de51ddc666936c"
 dependencies = [
  "no_std_io2",
- "unsigned-varint 0.8.0",
-]
-
-[[package]]
-name = "multihash-derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
-dependencies = [
- "proc-macro-crate 1.1.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure 0.12.6",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -3588,7 +3669,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3603,7 +3684,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3689,7 +3770,7 @@ dependencies = [
  "crc32fast",
  "flate2",
  "hashbrown 0.16.1",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "memchr",
  "ruzstd",
 ]
@@ -3749,11 +3830,11 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3787,9 +3868,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -3834,7 +3915,7 @@ version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4001,9 +4082,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -4030,9 +4111,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -4081,16 +4162,6 @@ dependencies = [
  "impl-codec",
  "impl-serde",
  "uint",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
-dependencies = [
- "thiserror 1.0.69",
- "toml 0.5.11",
 ]
 
 [[package]]
@@ -4273,7 +4344,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4337,9 +4408,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4348,9 +4419,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4417,7 +4488,7 @@ version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "593d142cfebb4f8a2f3c97862b2381d711faa98a30f2497df441ac51580a1edf"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -4428,9 +4499,9 @@ checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -4452,16 +4523,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4651,7 +4722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4e35aaaa439a5bda2f8d15251bc375e4edfac75f9865734644782c9701b5709"
 dependencies = [
  "ahash",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "instant",
  "num-traits",
  "once_cell",
@@ -4695,7 +4766,7 @@ dependencies = [
  "bytecheck",
  "bytes",
  "hashbrown 0.16.1",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "munge",
  "ptr_meta",
  "rancor",
@@ -4758,7 +4829,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4767,9 +4838,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4841,9 +4912,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4911,7 +4982,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -4924,7 +4995,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5079,7 +5150,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -5131,9 +5202,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -5417,18 +5488,6 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
@@ -5444,7 +5503,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5546,9 +5605,9 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "5.3.0-pre.8"
+version = "5.3.0-pre.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab431cede9976224597df0ba60f85faf35833cda5068400af9aff256f84d5f8"
+checksum = "5f2249ca2614013cfb96c7604f8f7b43143963f7ba672bd217c604f1c2e0d4c3"
 dependencies = [
  "anyhow",
  "cargo_toml 0.20.5",
@@ -5570,16 +5629,16 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "5.3.0-pre.8"
+version = "5.3.0-pre.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff31b48d69d09d31de0a74641cd36235f26e2729d7e5b110ffc9405882fec30"
+checksum = "9a636af9395dfc30a31307f19a86611fdcdd5ca63f5a36ff8a50951e8d93f89d"
 dependencies = [
  "argon2 0.4.1",
  "base64 0.22.1",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "blake2",
  "borsh",
- "bs58 0.5.1",
+ "bs58",
  "chacha20 0.7.3",
  "chacha20poly1305",
  "crc32fast",
@@ -5589,7 +5648,7 @@ dependencies = [
  "newtype-ops",
  "once_cell",
  "primitive-types",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "strum 0.22.0",
@@ -5653,10 +5712,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e375751e9b151312833f425a80f6417f0f502f07c35b26941cb64dd09cd4259"
 dependencies = [
  "blake2",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "ootle_byte_type",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "tari_bor",
  "tari_crypto",
@@ -5684,12 +5743,12 @@ dependencies = [
  "bounded-vec",
  "digest 0.10.7",
  "hex",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "lazy_static",
  "log",
  "ootle_byte_type",
  "ootle_serde",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "tari_bor",
@@ -5703,15 +5762,15 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "5.3.0-pre.8"
+version = "5.3.0-pre.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa6202ebe8c03e813216bbf0919947b74728dd4267a5183a1faa183d94823b3"
+checksum = "edb1ae793ad96131d7b55097e9e51bfc2a959f9d49c40b38b5f8e969bc4d8c96"
 
 [[package]]
 name = "tari_hashing"
-version = "5.3.0-pre.8"
+version = "5.3.0-pre.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8124b984cdc790948016a26a10683362243ecde047c7a0d75b73d3046f65ed5b"
+checksum = "14121ecd127eb248aec07417e2674cfbaefb970c526d66b1f1362c76eba33508"
 dependencies = [
  "blake2",
  "borsh",
@@ -5745,13 +5804,13 @@ dependencies = [
 
 [[package]]
 name = "tari_jellyfish"
-version = "5.3.0-pre.8"
+version = "5.3.0-pre.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be28e1c57605a1292bf931d593e44d62edbc2289b1f4bf409cee9a328fcddbfe"
+checksum = "64d9f9a6c06f70f4be7d23f19f8568d52e23360136141062ccd37f999c60ad46"
 dependencies = [
  "borsh",
  "digest 0.10.7",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde",
  "tari_crypto",
  "tari_hashing",
@@ -5760,9 +5819,9 @@ dependencies = [
 
 [[package]]
 name = "tari_max_size"
-version = "5.3.0-pre.8"
+version = "5.3.0-pre.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7970ad28c626e6826f8b29cc8d9448bf7b9d3f57d8ce58d84bc59bb5bd3c2e28"
+checksum = "d0b592ad03c3e20a47ecbdf69b11ec80ad9f659325a5d898f17be5cac843724a"
 dependencies = [
  "borsh",
  "serde",
@@ -5796,13 +5855,13 @@ dependencies = [
  "bounded-vec",
  "digest 0.10.7",
  "ethnum",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "newtype-ops",
  "ootle_byte_type",
  "ootle_serde",
  "prost 0.14.3",
  "prost-types",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "tari_bor",
  "tari_crypto",
@@ -5843,7 +5902,7 @@ dependencies = [
  "cargo_toml 0.22.3",
  "gix-hash 0.15.1",
  "hex",
- "multihash 0.19.4",
+ "multihash",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -5861,11 +5920,11 @@ checksum = "54a04198a911aecf87614124fd9d6f1809f47b0496e9a4abc77c26adae434afb"
 dependencies = [
  "borsh",
  "hex",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "ootle_byte_type",
  "ootle_serde",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "tari_bor",
  "tari_crypto",
@@ -5891,7 +5950,7 @@ dependencies = [
  "digest 0.10.7",
  "log",
  "ootle_byte_type",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "subtle",
  "tari_crypto",
@@ -5918,7 +5977,7 @@ dependencies = [
  "ootle_byte_type",
  "ootle_serde",
  "passwords",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "tari_bor",
  "tari_common_types",
@@ -5968,9 +6027,9 @@ dependencies = [
 
 [[package]]
 name = "tari_sidechain"
-version = "5.3.0-pre.8"
+version = "5.3.0-pre.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2557708aff9450fd430f845cb33f4f980452dd609e210739ae8f10418b6f05"
+checksum = "67ee1feb279e3ae8551b5bdaa3174dfe57d265882b19b2788ed34dd8a91ec07c"
 dependencies = [
  "borsh",
  "hex",
@@ -6123,9 +6182,9 @@ dependencies = [
 
 [[package]]
 name = "thin-vec"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da322882471314edc77fa5232c587bcb87c9df52bfd0d7d4826f8868ead61899"
+checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 
 [[package]]
 name = "thiserror"
@@ -6263,9 +6322,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -6325,15 +6384,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
@@ -6350,7 +6400,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -6365,7 +6415,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -6407,7 +6457,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -6421,7 +6471,7 @@ version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -6492,7 +6542,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -6522,7 +6572,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -6606,9 +6656,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -6706,12 +6756,6 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "unsigned-varint"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
-
-[[package]]
-name = "unsigned-varint"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
@@ -6753,7 +6797,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -6772,9 +6816,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -6821,11 +6865,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -6834,14 +6878,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6852,9 +6896,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6862,9 +6906,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6872,9 +6916,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6885,9 +6929,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -6904,12 +6948,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.246.2"
+version = "0.247.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
+checksum = "30b6733b8b91d010a6ac5b0fb237dc46a19650bc4c67db66857e2e787d437204"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.246.2",
+ "wasmparser 0.247.0",
 ]
 
 [[package]]
@@ -6919,7 +6963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
 ]
@@ -6935,7 +6979,7 @@ dependencies = [
  "cfg-if",
  "cmake",
  "derive_more",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "js-sys",
  "more-asserts",
  "paste",
@@ -7004,7 +7048,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "gimli 0.33.0",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "leb128",
  "more-asserts",
@@ -7050,7 +7094,7 @@ dependencies = [
  "enumset",
  "getrandom 0.4.2",
  "hex",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "more-asserts",
  "rkyv",
  "sha2 0.11.0",
@@ -7074,7 +7118,7 @@ dependencies = [
  "enum-iterator",
  "fnv",
  "gimli 0.33.0",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "libc",
  "libunwind",
@@ -7096,9 +7140,9 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -7108,17 +7152,17 @@ version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.246.2"
+version = "0.247.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
+checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
 dependencies = [
- "bitflags 2.11.0",
- "indexmap 2.13.1",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -7133,31 +7177,31 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "246.0.2"
+version = "247.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3fe8e3bf88ad96d031b4181ddbd64634b17cb0d06dfc3de589ef43591a9a62"
+checksum = "579d2d47eb33b0cdf9b14723cb115f1e1b7d6e77aac6f0816e5b7c7aeaa418ff"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.2",
- "wasm-encoder 0.246.2",
+ "wasm-encoder 0.247.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.246.2"
+version = "1.247.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd7fda1199b94fff395c2d19a153f05dbe7807630316fa9673367666fd2ad8c"
+checksum = "f3f4091c56437e86f2b57fa2fac72c4f528957a605b3f44f7c0b3b19a17ac5ee"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7214,7 +7258,7 @@ dependencies = [
  "nom",
  "openssl",
  "openssl-sys",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "serde",
  "serde_cbor_2",
@@ -7243,18 +7287,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7593,6 +7637,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "wit-bindgen-core"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7611,7 +7661,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -7641,8 +7691,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.1",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -7661,7 +7711,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -7739,7 +7789,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]
@@ -7780,7 +7830,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,8 +1074,6 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 [[package]]
 name = "core2"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
 dependencies = [
  "memchr",
 ]
@@ -2679,7 +2677,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3542,11 +3540,11 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.3"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
+checksum = "89ace881e3f514092ce9efbcb8f413d0ad9763860b828981c2de51ddc666936c"
 dependencies = [
- "core2",
+ "no_std_io2",
  "unsigned-varint 0.8.0",
 ]
 
@@ -3609,6 +3607,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3714,7 +3721,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ootle_byte_type"
-version = "0.6.0"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "752a5944471f02f6971359e2631af8f8eeb85acce3f7e5d74b60af43529220f9"
 dependencies = [
  "tari_crypto",
  "tari_template_lib_types",
@@ -3723,19 +3732,10 @@ dependencies = [
 [[package]]
 name = "ootle_serde"
 version = "0.2.0"
-dependencies = [
- "base64 0.22.1",
- "hex",
- "serde",
- "tari_bor",
-]
-
-[[package]]
-name = "ootle_serde"
-version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ebf90e42bffb2436ce6732a023b0cd48de62c981fcbfdef88fa4b3b7f31d867"
 dependencies = [
+ "base64 0.22.1",
  "hex",
  "serde",
  "tari_bor",
@@ -4256,7 +4256,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4294,7 +4294,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5484,7 +5484,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tari-ootle-cli"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "cargo-generate",
@@ -5514,6 +5514,8 @@ dependencies = [
 [[package]]
 name = "tari_bor"
 version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a42eeda12c38655b5a348e0ab99370affc27477eadd6af0a6736374ecf0ef68"
 dependencies = [
  "borsh",
  "ciborium",
@@ -5544,8 +5546,9 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "5.3.0-pre.4"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.4#cd40a655abb117e43a87fcdbd9bb7d78f18cd6a3"
+version = "5.3.0-pre.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ab431cede9976224597df0ba60f85faf35833cda5068400af9aff256f84d5f8"
 dependencies = [
  "anyhow",
  "cargo_toml 0.20.5",
@@ -5567,8 +5570,9 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "5.3.0-pre.4"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.4#cd40a655abb117e43a87fcdbd9bb7d78f18cd6a3"
+version = "5.3.0-pre.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff31b48d69d09d31de0a74641cd36235f26e2729d7e5b110ffc9405882fec30"
 dependencies = [
  "argon2 0.4.1",
  "base64 0.22.1",
@@ -5593,7 +5597,7 @@ dependencies = [
  "subtle",
  "tari_common",
  "tari_crypto",
- "tari_hashing 5.3.0-pre.4 (git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.4)",
+ "tari_hashing",
  "tari_max_size",
  "tari_utilities",
  "thiserror 2.0.18",
@@ -5604,14 +5608,16 @@ dependencies = [
 [[package]]
 name = "tari_consensus_types"
 version = "0.28.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9001691a7dcc687ee96cb0e6244c4d7f6bd5a1658d8102fb5e929d7970d9810c"
 dependencies = [
  "borsh",
- "ootle_serde 0.2.0",
+ "ootle_serde",
  "serde",
  "tari_common_types",
  "tari_crypto",
  "tari_engine_types",
- "tari_hashing 5.3.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing",
  "tari_ootle_common_types",
  "tari_sidechain",
  "tari_template_lib",
@@ -5643,6 +5649,8 @@ dependencies = [
 [[package]]
 name = "tari_engine"
 version = "0.28.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e375751e9b151312833f425a80f6417f0f502f07c35b26941cb64dd09cd4259"
 dependencies = [
  "blake2",
  "indexmap 2.13.1",
@@ -5668,6 +5676,8 @@ dependencies = [
 [[package]]
 name = "tari_engine_types"
 version = "0.28.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e42094418ea29938b001b095dad15102b0b8ecf5e010b88d31355f60995324b"
 dependencies = [
  "blake2",
  "borsh",
@@ -5678,13 +5688,13 @@ dependencies = [
  "lazy_static",
  "log",
  "ootle_byte_type",
- "ootle_serde 0.2.0",
+ "ootle_serde",
  "rand 0.8.5",
  "serde",
  "serde_json",
  "tari_bor",
  "tari_crypto",
- "tari_hashing 5.3.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing",
  "tari_ootle_template_metadata",
  "tari_template_abi",
  "tari_template_lib",
@@ -5693,25 +5703,15 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "5.3.0-pre.4"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.4#cd40a655abb117e43a87fcdbd9bb7d78f18cd6a3"
-
-[[package]]
-name = "tari_hashing"
-version = "5.3.0-pre.4"
+version = "5.3.0-pre.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a5302039a1a4765e2a39e26425c6d6b8375136c0159ad378dcd16b591331622"
-dependencies = [
- "blake2",
- "borsh",
- "digest 0.10.7",
- "tari_crypto",
-]
+checksum = "5fa6202ebe8c03e813216bbf0919947b74728dd4267a5183a1faa183d94823b3"
 
 [[package]]
 name = "tari_hashing"
-version = "5.3.0-pre.4"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.4#cd40a655abb117e43a87fcdbd9bb7d78f18cd6a3"
+version = "5.3.0-pre.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8124b984cdc790948016a26a10683362243ecde047c7a0d75b73d3046f65ed5b"
 dependencies = [
  "blake2",
  "borsh",
@@ -5722,6 +5722,8 @@ dependencies = [
 [[package]]
 name = "tari_indexer_client"
 version = "0.28.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd289cf76e9a2fb6d75ea01825b7b62391657ab1fabd33b112258c578e473b3"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -5743,22 +5745,24 @@ dependencies = [
 
 [[package]]
 name = "tari_jellyfish"
-version = "5.3.0-pre.4"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.4#cd40a655abb117e43a87fcdbd9bb7d78f18cd6a3"
+version = "5.3.0-pre.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be28e1c57605a1292bf931d593e44d62edbc2289b1f4bf409cee9a328fcddbfe"
 dependencies = [
  "borsh",
  "digest 0.10.7",
  "indexmap 2.13.1",
  "serde",
  "tari_crypto",
- "tari_hashing 5.3.0-pre.4 (git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.4)",
+ "tari_hashing",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "tari_max_size"
-version = "5.3.0-pre.4"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.4#cd40a655abb117e43a87fcdbd9bb7d78f18cd6a3"
+version = "5.3.0-pre.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7970ad28c626e6826f8b29cc8d9448bf7b9d3f57d8ce58d84bc59bb5bd3c2e28"
 dependencies = [
  "borsh",
  "serde",
@@ -5768,7 +5772,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_address"
-version = "0.4.0"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e628fe535b4e1b76e90ab1842b2c31ae34a64c51e9721426e59de93d91823cc2"
 dependencies = [
  "bech32",
  "ootle_byte_type",
@@ -5782,6 +5788,8 @@ dependencies = [
 [[package]]
 name = "tari_ootle_common_types"
 version = "0.28.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcb849e9e37ab99f63e2e726fb9baf5c1885e942a6cb0184c122256d1c1e63e5"
 dependencies = [
  "blake2",
  "borsh",
@@ -5791,7 +5799,7 @@ dependencies = [
  "indexmap 2.13.1",
  "newtype-ops",
  "ootle_byte_type",
- "ootle_serde 0.2.0",
+ "ootle_serde",
  "prost 0.14.3",
  "prost-types",
  "rand 0.8.5",
@@ -5799,7 +5807,7 @@ dependencies = [
  "tari_bor",
  "tari_crypto",
  "tari_engine_types",
- "tari_hashing 5.3.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing",
  "tari_ootle_template_metadata",
  "tari_template_lib_types",
  "thiserror 2.0.18",
@@ -5807,10 +5815,10 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_publish_lib"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "hickory-proto",
- "ootle_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ootle_serde",
  "serde",
  "tari_engine",
  "tari_engine_types",
@@ -5827,13 +5835,15 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_metadata"
-version = "0.5.0"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad7f49ffe82406661e8ae57702bc6c28d5a6dc10448ed8e445a071d0cd1854c"
 dependencies = [
  "borsh",
  "cargo_toml 0.22.3",
  "gix-hash 0.15.1",
  "hex",
- "multihash 0.19.3",
+ "multihash 0.19.4",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -5846,19 +5856,21 @@ dependencies = [
 [[package]]
 name = "tari_ootle_transaction"
 version = "0.28.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a04198a911aecf87614124fd9d6f1809f47b0496e9a4abc77c26adae434afb"
 dependencies = [
  "borsh",
  "hex",
  "indexmap 2.13.1",
  "log",
  "ootle_byte_type",
- "ootle_serde 0.2.0",
+ "ootle_serde",
  "rand 0.8.5",
  "serde",
  "tari_bor",
  "tari_crypto",
  "tari_engine_types",
- "tari_hashing 5.3.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing",
  "tari_ootle_common_types",
  "tari_ootle_template_metadata",
  "tari_template_lib_types",
@@ -5868,6 +5880,8 @@ dependencies = [
 [[package]]
 name = "tari_ootle_wallet_crypto"
 version = "0.28.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18fa74d2fc70e4e51fd5bc6718abab7622839b51190d6e2677dbb61766687a9c"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -5882,7 +5896,7 @@ dependencies = [
  "subtle",
  "tari_crypto",
  "tari_engine_types",
- "tari_hashing 5.3.0-pre.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tari_hashing",
  "tari_ootle_common_types",
  "tari_template_lib_types",
  "tari_utilities",
@@ -5893,6 +5907,8 @@ dependencies = [
 [[package]]
 name = "tari_ootle_wallet_sdk"
 version = "0.28.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c56b32511b3f8a700e0114867fb41b6de56d5b1512d30633c90a9a91c0ffeac"
 dependencies = [
  "anyhow",
  "digest 0.10.7",
@@ -5900,7 +5916,7 @@ dependencies = [
  "keyring",
  "log",
  "ootle_byte_type",
- "ootle_serde 0.2.0",
+ "ootle_serde",
  "passwords",
  "rand 0.8.5",
  "serde",
@@ -5926,10 +5942,12 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.29.2"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cb49c316a1940ebaeb323d93eda527f9cf040448258a29fcb6132f010f6538b"
 dependencies = [
  "hex",
- "ootle_serde 0.2.0",
+ "ootle_serde",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
@@ -5950,8 +5968,9 @@ dependencies = [
 
 [[package]]
 name = "tari_sidechain"
-version = "5.3.0-pre.4"
-source = "git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.4#cd40a655abb117e43a87fcdbd9bb7d78f18cd6a3"
+version = "5.3.0-pre.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2557708aff9450fd430f845cb33f4f980452dd609e210739ae8f10418b6f05"
 dependencies = [
  "borsh",
  "hex",
@@ -5959,7 +5978,7 @@ dependencies = [
  "serde",
  "tari_common_types",
  "tari_crypto",
- "tari_hashing 5.3.0-pre.4 (git+https://github.com/tari-project/tari.git?tag=v5.3.0-pre.4)",
+ "tari_hashing",
  "tari_jellyfish",
  "tari_utilities",
  "thiserror 2.0.18",
@@ -5968,6 +5987,8 @@ dependencies = [
 [[package]]
 name = "tari_template_abi"
 version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bdb2b66b9db191152ec10f637657cd20f27151576f059fb215409ca09c10d93"
 dependencies = [
  "serde",
  "tari_bor",
@@ -5977,6 +5998,8 @@ dependencies = [
 [[package]]
 name = "tari_template_builtin"
 version = "0.28.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2010371161688f889080756deaafe0d60de18617c130642bb8585b6893dc539b"
 dependencies = [
  "anyhow",
  "tari_template_lib_types",
@@ -5984,7 +6007,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.24.0"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbcc87952508325c24acc5fe6c62fbc88a179b4fb2d175de301839248c79a607"
 dependencies = [
  "borsh",
  "serde",
@@ -5996,7 +6021,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib_types"
-version = "0.24.0"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c86ba01fed934a07f58b33257c21fac6ecdf650e29f5f40c5f6b1568c91ef6a"
 dependencies = [
  "bnum",
  "borsh",
@@ -6009,6 +6036,8 @@ dependencies = [
 [[package]]
 name = "tari_template_macros"
 version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4280c01eff9d0ba0e302a41c2f5b59c214bde5a8bc63a9b3881750ac6c1843d6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7813,7 +7842,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[patch.unused]]
-name = "tari_ootle_template_build"
-version = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,19 @@ tari_engine = "0.28"
 tari_engine_types = "0.28"
 tari_ootle_common_types = "0.28"
 tari_template_lib_types = "0.24"
-tari_ootle_template_metadata = "0.4"
+tari_ootle_template_metadata = "0.5"
+
+# Temporary path overrides until the next coordinated Ootle release.
+# All these crates transitively depend on tari_ootle_template_metadata;
+# pointing them at the local repo ensures a single version (0.5).
+[patch.crates-io]
+tari_ootle_template_metadata = { path = "../dan/crates/template_metadata" }
+tari_ootle_template_build = { path = "../dan/crates/template_build" }
+tari_engine = { path = "../dan/crates/engine" }
+tari_engine_types = { path = "../dan/crates/engine_types" }
+tari_ootle_common_types = { path = "../dan/crates/common_types" }
+tari_ootle_transaction = { path = "../dan/crates/transaction" }
+tari_template_lib_types = { path = "../dan/crates/template_lib_types" }
+tari_ootle_walletd_client = { path = "../dan/clients/wallet_daemon_client" }
+tari_ootle_wallet_sdk = { path = "../dan/crates/wallet/sdk" }
+tari_bor = { path = "../dan/crates/tari_bor" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@ members = ["crates/publish_lib", "crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-cli"
 license = "BSD-3-Clause"
 
 [workspace.dependencies]
-tari_ootle_publish_lib = { path = "crates/publish_lib", version = "0.14" }
+tari_ootle_publish_lib = { path = "crates/publish_lib", version = "0.15" }
 
 tokio = { version = "1.41.1", features = ["full"] }
 serde = { version = "1.0.215", features = ["derive"] }
@@ -21,20 +21,5 @@ tari_ootle_walletd_client = "0.29"
 tari_engine = "0.28"
 tari_engine_types = "0.28"
 tari_ootle_common_types = "0.28"
-tari_template_lib_types = "0.24"
+tari_template_lib_types = "0.25"
 tari_ootle_template_metadata = "0.5"
-
-# Temporary path overrides until the next coordinated Ootle release.
-# All these crates transitively depend on tari_ootle_template_metadata;
-# pointing them at the local repo ensures a single version (0.5).
-[patch.crates-io]
-tari_ootle_template_metadata = { path = "../dan/crates/template_metadata" }
-tari_ootle_template_build = { path = "../dan/crates/template_build" }
-tari_engine = { path = "../dan/crates/engine" }
-tari_engine_types = { path = "../dan/crates/engine_types" }
-tari_ootle_common_types = { path = "../dan/crates/common_types" }
-tari_ootle_transaction = { path = "../dan/crates/transaction" }
-tari_template_lib_types = { path = "../dan/crates/template_lib_types" }
-tari_ootle_walletd_client = { path = "../dan/clients/wallet_daemon_client" }
-tari_ootle_wallet_sdk = { path = "../dan/crates/wallet/sdk" }
-tari_bor = { path = "../dan/crates/tari_bor" }

--- a/crates/cli/src/cli/commands/metadata/publish.rs
+++ b/crates/cli/src/cli/commands/metadata/publish.rs
@@ -4,6 +4,8 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use crate::cli::commands::publish::{find_metadata_cbor, load_project_config};
+use crate::cli::config::Config;
 use anyhow::{Context, anyhow};
 use clap::Parser;
 use dialoguer::Confirm;
@@ -11,11 +13,6 @@ use tari_engine_types::published_template::PublishedTemplateAddress;
 use tari_ootle_publish_lib::publisher::{SignedMetadataPayload, TemplatePublisher};
 use tari_ootle_template_metadata::TemplateMetadata;
 use url::Url;
-
-use crate::cli::commands::publish::{find_metadata_cbor, load_project_config};
-use crate::cli::config::Config;
-
-const DEFAULT_METADATA_SERVER: &str = "http://localhost:3000";
 
 /// Default retry settings: 6 attempts, 10s initial backoff (10, 20, 40, 80, 160s ≈ ~5 min total).
 const DEFAULT_MAX_RETRIES: u32 = 6;
@@ -59,6 +56,14 @@ pub struct PublishMetadataArgs {
     pub wallet_daemon_url: Option<url::Url>,
 }
 
+fn get_default_metadata_server_url(network: &str) -> Option<&'static str> {
+    match network {
+        "localnet" => Some("http://localhost:3000"),
+        "esmeralda" => Some("https://ootle-templates-esme.tari.com/"),
+        _ => None,
+    }
+}
+
 pub async fn handle(config: Config, args: PublishMetadataArgs) -> anyhow::Result<()> {
     let cbor_path = find_metadata_cbor(&args.path).await?;
     let mut cbor_bytes = std::fs::read(&cbor_path).context("reading metadata CBOR file")?;
@@ -66,14 +71,31 @@ pub async fn handle(config: Config, args: PublishMetadataArgs) -> anyhow::Result
     let url_override = args.wallet_daemon_url.as_ref().or(config.wallet_daemon_url.as_ref());
     let project_config = load_project_config(&args.path, url_override).await?;
 
+    let publisher = TemplatePublisher::new(project_config.network().clone());
+
     // Resolve metadata server URL: CLI flag > project config > global config > default
-    let default_url: Url = DEFAULT_METADATA_SERVER.parse().unwrap();
     let metadata_server_url = args
         .metadata_server_url
         .as_ref()
         .or(project_config.metadata_server_url())
         .or(config.metadata_server_url.as_ref())
-        .unwrap_or(&default_url);
+        .cloned();
+
+    let metadata_server_url = match metadata_server_url {
+        Some(url) => url,
+        None => {
+            let resp = publisher
+                .wallet_daemon_client()
+                .await?
+                .get_settings()
+                .await
+                .context("fetching network settings from wallet daemon")?;
+            let default_url = get_default_metadata_server_url(&resp.network.name)
+                .ok_or_else(|| anyhow!("no default metadata server for {}", resp.network.name))?;
+            let default_url: Url = default_url.parse().expect("parse default url");
+            default_url
+        },
+    };
 
     let mut metadata =
         TemplateMetadata::from_cbor(&cbor_bytes).context("metadata CBOR is invalid — cannot publish corrupt data")?;
@@ -120,8 +142,6 @@ pub async fn handle(config: Config, args: PublishMetadataArgs) -> anyhow::Result
     );
 
     if args.signed {
-        let publisher = TemplatePublisher::new(project_config.network().clone());
-
         let payload = publisher
             .sign_metadata_for_publish(args.key_index, addr.as_template_address(), metadata)
             .await
@@ -129,9 +149,9 @@ pub async fn handle(config: Config, args: PublishMetadataArgs) -> anyhow::Result
 
         println!("🔑 Signed as author: {}", payload.public_key);
 
-        publish_metadata_signed(metadata_server_url, &addr, &payload, args.max_retries).await
+        publish_metadata_signed(&metadata_server_url, &addr, &payload, args.max_retries).await
     } else {
-        publish_metadata_to_server(metadata_server_url, &addr, &cbor_bytes, args.max_retries).await
+        publish_metadata_to_server(&metadata_server_url, &addr, &cbor_bytes, args.max_retries).await
     }
 }
 

--- a/crates/cli/src/cli/commands/template/init_metadata.rs
+++ b/crates/cli/src/cli/commands/template/init_metadata.rs
@@ -179,13 +179,6 @@ fn resolve_metadata(args: &InitMetadataArgs) -> anyhow::Result<TemplateMetadataI
         .interact_text()?;
     let logo_url = if logo_url.is_empty() { None } else { Some(logo_url) };
 
-    let supersedes: String = Input::new()
-        .with_prompt("Supersedes template address (64-char hex, leave empty to skip)")
-        .default(args.supersedes.clone().unwrap_or_default())
-        .allow_empty(true)
-        .interact_text()?;
-    let supersedes = if supersedes.is_empty() { None } else { Some(supersedes) };
-
     Ok(TemplateMetadataInput {
         description,
         tags,
@@ -193,7 +186,7 @@ fn resolve_metadata(args: &InitMetadataArgs) -> anyhow::Result<TemplateMetadataI
         documentation,
         homepage,
         logo_url,
-        supersedes,
+        supersedes: None,
     })
 }
 

--- a/crates/cli/src/cli/commands/template/init_metadata.rs
+++ b/crates/cli/src/cli/commands/template/init_metadata.rs
@@ -9,7 +9,7 @@ use dialoguer::Input;
 use tokio::fs;
 
 const BUILD_DEP_KEY: &str = "tari_ootle_template_build";
-const BUILD_DEP_VERSION: &str = "0.4";
+const BUILD_DEP_VERSION: &str = "0.5";
 const BUILD_RS_CONTENT: &str = r#"fn main() {
     tari_ootle_template_build::TemplateMetadataBuilder::new()
         .build()
@@ -50,6 +50,10 @@ pub struct InitMetadataArgs {
     #[arg(long)]
     pub logo_url: Option<String>,
 
+    /// Template address of a previous version that this template supersedes (64-char hex).
+    #[arg(long)]
+    pub supersedes: Option<String>,
+
     /// Skip interactive prompts (use only provided CLI args).
     #[arg(long, short = 'y')]
     pub non_interactive: bool,
@@ -89,6 +93,7 @@ struct TemplateMetadataInput {
     documentation: Option<String>,
     homepage: Option<String>,
     logo_url: Option<String>,
+    supersedes: Option<String>,
 }
 
 fn resolve_metadata(args: &InitMetadataArgs) -> anyhow::Result<TemplateMetadataInput> {
@@ -113,6 +118,7 @@ fn resolve_metadata(args: &InitMetadataArgs) -> anyhow::Result<TemplateMetadataI
             documentation: args.documentation.clone(),
             homepage: args.homepage.clone(),
             logo_url: args.logo_url.clone(),
+            supersedes: args.supersedes.clone(),
         });
     }
 
@@ -173,6 +179,13 @@ fn resolve_metadata(args: &InitMetadataArgs) -> anyhow::Result<TemplateMetadataI
         .interact_text()?;
     let logo_url = if logo_url.is_empty() { None } else { Some(logo_url) };
 
+    let supersedes: String = Input::new()
+        .with_prompt("Supersedes template address (64-char hex, leave empty to skip)")
+        .default(args.supersedes.clone().unwrap_or_default())
+        .allow_empty(true)
+        .interact_text()?;
+    let supersedes = if supersedes.is_empty() { None } else { Some(supersedes) };
+
     Ok(TemplateMetadataInput {
         description,
         tags,
@@ -180,6 +193,7 @@ fn resolve_metadata(args: &InitMetadataArgs) -> anyhow::Result<TemplateMetadataI
         documentation,
         homepage,
         logo_url,
+        supersedes,
     })
 }
 
@@ -257,6 +271,10 @@ fn add_template_metadata(cargo_toml_content: &str, metadata: &TemplateMetadataIn
         tari_template.insert("logo_url", toml_edit::value(logo_url.as_str()));
     }
 
+    if let Some(ref supersedes) = metadata.supersedes {
+        tari_template.insert("supersedes", toml_edit::value(supersedes.as_str()));
+    }
+
     Ok(doc.to_string())
 }
 
@@ -282,6 +300,7 @@ pub async fn auto_init(crate_dir: &Path) -> anyhow::Result<()> {
         documentation: None,
         homepage: None,
         logo_url: None,
+        supersedes: None,
     };
 
     let updated = add_build_dependency(&content)?;
@@ -368,6 +387,7 @@ version = "0.1.0"
             documentation: None,
             homepage: Some("https://example.com".to_string()),
             logo_url: None,
+            supersedes: None,
         };
         let result = add_template_metadata(input, &metadata).unwrap();
         assert!(result.contains("[package.metadata.tari-template]"));
@@ -394,6 +414,7 @@ category = "old-category"
             documentation: None,
             homepage: None,
             logo_url: None,
+            supersedes: None,
         };
         let result = add_template_metadata(input, &metadata).unwrap();
         assert!(result.contains("new-category"));
@@ -413,6 +434,7 @@ version = "0.1.0"
             documentation: None,
             homepage: None,
             logo_url: None,
+            supersedes: None,
         };
         let result = add_template_metadata(input, &metadata).unwrap();
         // Should still create the section even if empty

--- a/crates/cli/src/cli/commands/template/init_metadata.rs
+++ b/crates/cli/src/cli/commands/template/init_metadata.rs
@@ -118,7 +118,7 @@ fn resolve_metadata(args: &InitMetadataArgs) -> anyhow::Result<TemplateMetadataI
             documentation: args.documentation.clone(),
             homepage: args.homepage.clone(),
             logo_url: args.logo_url.clone(),
-            supersedes: args.supersedes.clone(),
+            supersedes: normalize_supersedes(args.supersedes.as_deref()),
         });
     }
 
@@ -186,8 +186,12 @@ fn resolve_metadata(args: &InitMetadataArgs) -> anyhow::Result<TemplateMetadataI
         documentation,
         homepage,
         logo_url,
-        supersedes: None,
+        supersedes: normalize_supersedes(args.supersedes.as_deref()),
     })
+}
+
+fn normalize_supersedes(s: Option<&str>) -> Option<String> {
+    s.map(str::trim).filter(|s| !s.is_empty()).map(str::to_string)
 }
 
 fn add_build_dependency(cargo_toml_content: &str) -> anyhow::Result<String> {

--- a/crates/cli/src/cli/commands/template/inspect_metadata.rs
+++ b/crates/cli/src/cli/commands/template/inspect_metadata.rs
@@ -99,6 +99,9 @@ fn print_metadata_table(metadata: &TemplateMetadata, hash: &tari_ootle_template_
     if let Some(ref repo) = metadata.repository {
         println!("  Repository:     {repo}");
     }
+    if let Some(ref commit_hash) = metadata.commit_hash {
+        println!("  Commit hash:    {commit_hash}");
+    }
     if let Some(ref docs) = metadata.documentation {
         println!("  Documentation:  {docs}");
     }
@@ -107,6 +110,9 @@ fn print_metadata_table(metadata: &TemplateMetadata, hash: &tari_ootle_template_
     }
     if let Some(ref logo_url) = metadata.logo_url {
         println!("  Logo URL:       {logo_url}");
+    }
+    if let Some(ref supersedes) = metadata.supersedes {
+        println!("  Supersedes:     {supersedes}");
     }
     if !metadata.extra.is_empty() {
         println!("  Extra:");

--- a/crates/cli/src/cli/commands/template/publish.rs
+++ b/crates/cli/src/cli/commands/template/publish.rs
@@ -114,6 +114,12 @@ pub async fn handle(config: Config, mut args: TemplatePublishArgs) -> anyhow::Re
             if let Some(ref license) = metadata.license {
                 println!("   License:     {license}");
             }
+            if let Some(ref commit_hash) = metadata.commit_hash {
+                println!("   Commit hash: {commit_hash}");
+            }
+            if let Some(ref supersedes) = metadata.supersedes {
+                println!("   Supersedes:  {supersedes}");
+            }
             Some(hash)
         },
         Err(e) => {

--- a/crates/cli/src/cli/commands/wizard.rs
+++ b/crates/cli/src/cli/commands/wizard.rs
@@ -195,6 +195,7 @@ async fn step_metadata(crate_dir: &Path) -> anyhow::Result<()> {
         documentation: None,
         homepage: None,
         logo_url: None,
+        supersedes: None,
         non_interactive: false,
     };
     init_metadata::handle(args).await?;

--- a/crates/cli/src/project/config.rs
+++ b/crates/cli/src/project/config.rs
@@ -9,6 +9,7 @@ use url::Url;
 
 /// Project configuration.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct ProjectConfig {
     network: NetworkConfig,
     default_account: Option<String>,

--- a/crates/publish_lib/Cargo.toml
+++ b/crates/publish_lib/Cargo.toml
@@ -14,7 +14,7 @@ tari_engine = { workspace = true }
 tari_engine_types = { workspace = true }
 tari_template_lib_types = { workspace = true }
 tari_ootle_template_metadata = { workspace = true }
-tari_ootle_wallet_sdk = "0.28.6"
+tari_ootle_wallet_sdk = "0.28.9"
 ootle_serde = { version = "0.2", features = ["hex"] }
 
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }

--- a/crates/publish_lib/src/publisher.rs
+++ b/crates/publish_lib/src/publisher.rs
@@ -275,7 +275,7 @@ impl TemplatePublisher {
     }
 
     /// Returns a new wallet daemon client.
-    async fn wallet_daemon_client(&self) -> Result<WalletDaemonClient> {
+    pub async fn wallet_daemon_client(&self) -> Result<WalletDaemonClient> {
         let mut client = WalletDaemonClient::connect(self.network.wallet_daemon_jrpc_address().clone(), None)?;
 
         let AuthGetMethodResponse { method } = client.get_auth_method().await?;


### PR DESCRIPTION
## Summary
- Bump `tari_ootle_template_metadata` to 0.5 and `tari_ootle_template_build` to 0.5
- Add `--supersedes` CLI arg to `tari template init` (interactive prompt + Cargo.toml writer)
- Display `commit_hash` and `supersedes` fields in `tari template inspect` and `tari template publish`
- Temporary `[patch.crates-io]` section for local Ootle path deps until next coordinated release

## Test plan
- [x] `cargo test` — all 7 tests pass
- [x] Manual: `tari template init --supersedes <addr>` writes to Cargo.toml
- [x] Manual: `tari template inspect` displays new fields