### PR TITLE
fix: use network-based default metadata server in `tari publish`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5543,7 +5543,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tari-ootle-cli"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "cargo-generate",
@@ -5874,7 +5874,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_publish_lib"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "hickory-proto",
  "ootle_serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/publish_lib", "crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.15.0"
+version = "0.15.1"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-cli"

--- a/crates/cli/src/cli/commands/metadata/publish.rs
+++ b/crates/cli/src/cli/commands/metadata/publish.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 use crate::cli::commands::publish::{find_metadata_cbor, load_project_config};
 use crate::cli::config::Config;
+use crate::cli::util::get_default_metadata_server_url;
 use anyhow::{Context, anyhow};
 use clap::Parser;
 use dialoguer::Confirm;
@@ -54,14 +55,6 @@ pub struct PublishMetadataArgs {
     /// Required with --signed.
     #[arg(long)]
     pub wallet_daemon_url: Option<url::Url>,
-}
-
-fn get_default_metadata_server_url(network: &str) -> Option<&'static str> {
-    match network {
-        "localnet" => Some("http://localhost:3000"),
-        "esmeralda" => Some("https://ootle-templates-esme.tari.com/"),
-        _ => None,
-    }
 }
 
 pub async fn handle(config: Config, args: PublishMetadataArgs) -> anyhow::Result<()> {

--- a/crates/cli/src/cli/commands/template/publish.rs
+++ b/crates/cli/src/cli/commands/template/publish.rs
@@ -16,6 +16,7 @@ use crate::cli::commands::metadata::publish::publish_metadata_to_server;
 use crate::cli::commands::publish::{build_template, find_metadata_cbor, load_project_config};
 use crate::cli::config::Config;
 use crate::cli::util;
+use crate::cli::util::get_default_metadata_server_url;
 use crate::loading;
 
 const MAX_WASM_SIZE: usize = 5 * 1000 * 1000; // 5 MB
@@ -209,13 +210,21 @@ pub async fn handle(config: Config, mut args: TemplatePublishArgs) -> anyhow::Re
         let cbor_path = find_metadata_cbor(crate_dir).await?;
         let cbor_bytes = std::fs::read(&cbor_path).context("reading metadata CBOR for server publish")?;
 
-        let default_url: url::Url = "http://localhost:3000".parse().unwrap();
+        let resolved_default = get_default_metadata_server_url(&info.network)
+            .map(|s| s.parse::<url::Url>().expect("parse default metadata server url"));
         let metadata_server_url = args
             .metadata_server_url
             .as_ref()
             .or(project_config.metadata_server_url())
             .or(config.metadata_server_url.as_ref())
-            .unwrap_or(&default_url);
+            .or(resolved_default.as_ref())
+            .ok_or_else(|| {
+                anyhow!(
+                    "No metadata server URL configured and no default known for network '{}'. \
+                     Pass --metadata-server-url or set it in tari.config.toml.",
+                    info.network
+                )
+            })?;
 
         println!("📡 Publishing metadata to {metadata_server_url}...");
         match publish_metadata_to_server(metadata_server_url, &published_addr, &cbor_bytes, 6).await {

--- a/crates/cli/src/cli/util.rs
+++ b/crates/cli/src/cli/util.rs
@@ -35,3 +35,11 @@ pub fn cli_select<'a, T: std::fmt::Display>(prompt: &str, items: &'a [T]) -> any
 pub fn human_bytes(n: usize) -> String {
     human_bytes::human_bytes(n as f64)
 }
+
+pub fn get_default_metadata_server_url(network: &str) -> Option<&'static str> {
+    match network {
+        "localnet" => Some("http://localhost:3000"),
+        "esmeralda" => Some("https://ootle-templates-esme.tari.com/"),
+        _ => None,
+    }
+}


### PR DESCRIPTION
## Summary
- `tari publish` previously hardcoded `http://localhost:3000` as the metadata server fallback, ignoring the active network
- Now resolves the default from the wallet network (matching `tari metadata publish`) — `localnet` → localhost, `esmeralda` → `https://ootle-templates-esme.tari.com/`
- Errors out if no default is known for the network, instead of silently submitting to the wrong server
- Moved `get_default_metadata_server_url` from `metadata/publish.rs` into `cli/util.rs` so both commands share it

## Test plan
- [ ] `tari publish --publish-metadata` on esmeralda posts to the esmeralda community server (not localhost)
- [ ] `tari publish --publish-metadata` on localnet still posts to `http://localhost:3000`
- [ ] `--metadata-server-url` flag and `tari.config.toml` value still override the default
- [ ] Unknown network surfaces a clear error asking for `--metadata-server-url`

🤖 Generated with [Claude Code](https://claude.com/claude-code)