### PR TITLE
feat: per-network config with --network override

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5559,6 +5559,7 @@ dependencies = [
  "serde_json",
  "spinners",
  "tari_engine_types",
+ "tari_ootle_common_types",
  "tari_ootle_publish_lib",
  "tari_ootle_template_metadata",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1812,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "faster-hex"
@@ -3223,9 +3223,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
 
 [[package]]
 name = "leb128fmt"
@@ -4912,9 +4912,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -5543,7 +5543,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tari-ootle-cli"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "cargo-generate",
@@ -5606,9 +5606,9 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "5.3.0-pre.10"
+version = "5.3.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2249ca2614013cfb96c7604f8f7b43143963f7ba672bd217c604f1c2e0d4c3"
+checksum = "c5e51cc5201ff066fd2a6bc5869a63be25c95f3bdfdf1f66e9a8e3fa6fd8c3dd"
 dependencies = [
  "anyhow",
  "cargo_toml 0.20.5",
@@ -5630,9 +5630,9 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "5.3.0-pre.10"
+version = "5.3.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a636af9395dfc30a31307f19a86611fdcdd5ca63f5a36ff8a50951e8d93f89d"
+checksum = "96b135f831c7efda9735ded24acacf9ac7c48a5349ee8c0480889d02cf7c80a3"
 dependencies = [
  "argon2 0.4.1",
  "base64 0.22.1",
@@ -5667,9 +5667,9 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.28.10"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9001691a7dcc687ee96cb0e6244c4d7f6bd5a1658d8102fb5e929d7970d9810c"
+checksum = "c5f96a7ce9babcd0dc3ba13a4b699f3a43a4938a07bcba4b90c5b9e1c03c19b4"
 dependencies = [
  "borsh",
  "ootle_serde",
@@ -5708,9 +5708,9 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.28.10"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e375751e9b151312833f425a80f6417f0f502f07c35b26941cb64dd09cd4259"
+checksum = "bc0d478036298a763c92923dc67cfc7e177b4247240901515a29fa2b705ef1d4"
 dependencies = [
  "blake2",
  "indexmap 2.14.0",
@@ -5735,9 +5735,9 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.28.10"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e42094418ea29938b001b095dad15102b0b8ecf5e010b88d31355f60995324b"
+checksum = "3883598c6002d7a61593dfd9965dea21020017fac07c38aa2375bfc985b613a4"
 dependencies = [
  "blake2",
  "borsh",
@@ -5763,15 +5763,15 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "5.3.0-pre.10"
+version = "5.3.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb1ae793ad96131d7b55097e9e51bfc2a959f9d49c40b38b5f8e969bc4d8c96"
+checksum = "db5e95b5208bdadcefd534a8c790e02baaf42cd29da54d2a10e9d41a49d714f9"
 
 [[package]]
 name = "tari_hashing"
-version = "5.3.0-pre.10"
+version = "5.3.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14121ecd127eb248aec07417e2674cfbaefb970c526d66b1f1362c76eba33508"
+checksum = "b99ff66f7fae442e1daf1dfacf96c09888bbe09eb8fc2268988ba1d049a66a69"
 dependencies = [
  "blake2",
  "borsh",
@@ -5781,9 +5781,9 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.28.10"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd289cf76e9a2fb6d75ea01825b7b62391657ab1fabd33b112258c578e473b3"
+checksum = "fe9b81f2c41e8dc92b88d05bad8f7e9d952df8b3a94946e3273ab4490dd486dd"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -5805,9 +5805,9 @@ dependencies = [
 
 [[package]]
 name = "tari_jellyfish"
-version = "5.3.0-pre.10"
+version = "5.3.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d9f9a6c06f70f4be7d23f19f8568d52e23360136141062ccd37f999c60ad46"
+checksum = "bdaa1185310000df5298fc47111d5846c178a9cec3c94e624e1b7d94d06f7b3d"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -5820,9 +5820,9 @@ dependencies = [
 
 [[package]]
 name = "tari_max_size"
-version = "5.3.0-pre.10"
+version = "5.3.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b592ad03c3e20a47ecbdf69b11ec80ad9f659325a5d898f17be5cac843724a"
+checksum = "7735c3c97a45952cb64ce5ee2688f34d57466ecd7feaa6a37fb6735f61ef1048"
 dependencies = [
  "borsh",
  "serde",
@@ -5832,9 +5832,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_address"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e628fe535b4e1b76e90ab1842b2c31ae34a64c51e9721426e59de93d91823cc2"
+checksum = "054299fe281f9c56caa3f70e6d5c779a3b34719727d465026ea4342454904580"
 dependencies = [
  "bech32",
  "ootle_byte_type",
@@ -5847,9 +5847,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.28.10"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcb849e9e37ab99f63e2e726fb9baf5c1885e942a6cb0184c122256d1c1e63e5"
+checksum = "1d7c58e5c455b70f72bbbc5535b0cb01673facceeaf2fea2b78359dadc7fe2c2"
 dependencies = [
  "blake2",
  "borsh",
@@ -5875,7 +5875,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_publish_lib"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "hickory-proto",
  "ootle_serde",
@@ -5915,9 +5915,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.28.10"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a04198a911aecf87614124fd9d6f1809f47b0496e9a4abc77c26adae434afb"
+checksum = "35bc78e59cdecbe9e06bfb1a039f7d22ab14826757de87f93265d78eb630958b"
 dependencies = [
  "borsh",
  "hex",
@@ -5939,9 +5939,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.28.10"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fa74d2fc70e4e51fd5bc6718abab7622839b51190d6e2677dbb61766687a9c"
+checksum = "05af6bc9f09301327885966cfdf6f40c29e1ca3431b3a76d8d3734672584a4f3"
 dependencies = [
  "argon2 0.5.3",
  "blake2",
@@ -5966,9 +5966,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.28.10"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c56b32511b3f8a700e0114867fb41b6de56d5b1512d30633c90a9a91c0ffeac"
+checksum = "83e26cf4dd933bdf1735c665a48aaa40fb594578aa7f34e403e72c5063ac4855"
 dependencies = [
  "anyhow",
  "digest 0.10.7",
@@ -6002,9 +6002,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.29.3"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb49c316a1940ebaeb323d93eda527f9cf040448258a29fcb6132f010f6538b"
+checksum = "ae82f98e482a46ae8a0f06cf886236fb2724491d41d7322ae2d5d9e5b713e625"
 dependencies = [
  "hex",
  "ootle_serde",
@@ -6028,9 +6028,9 @@ dependencies = [
 
 [[package]]
 name = "tari_sidechain"
-version = "5.3.0-pre.10"
+version = "5.3.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ee1feb279e3ae8551b5bdaa3174dfe57d265882b19b2788ed34dd8a91ec07c"
+checksum = "5aa2ecf36b51a3527ad7f7cff4812948d73595de494cee56dc15ad929d05f726"
 dependencies = [
  "borsh",
  "hex",
@@ -6057,9 +6057,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.28.10"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2010371161688f889080756deaafe0d60de18617c130642bb8585b6893dc539b"
+checksum = "420a3d6dc257a6463353a7d33f189987b3113eb06043c1ab29182193f4bc66c6"
 dependencies = [
  "anyhow",
  "tari_template_lib_types",
@@ -6067,9 +6067,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.25.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcc87952508325c24acc5fe6c62fbc88a179b4fb2d175de301839248c79a607"
+checksum = "fc55e55d40841a262fc0270a34db9241d6d93809dbd06e8da51e29e572dfc6d4"
 dependencies = [
  "borsh",
  "serde",
@@ -6081,9 +6081,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib_types"
-version = "0.25.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c86ba01fed934a07f58b33257c21fac6ecdf650e29f5f40c5f6b1568c91ef6a"
+checksum = "8fbe3f80db4ca6c62d449f850745a90082ade451e7d0b8b2fd17f76cde533a37"
 dependencies = [
  "bnum",
  "borsh",
@@ -6422,7 +6422,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -6476,7 +6476,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -6485,7 +6485,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -7621,9 +7621,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@ members = ["crates/publish_lib", "crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.15.1"
+version = "0.16.0"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-cli"
 license = "BSD-3-Clause"
 
 [workspace.dependencies]
-tari_ootle_publish_lib = { path = "crates/publish_lib", version = "0.15" }
+tari_ootle_publish_lib = { path = "crates/publish_lib", version = "0.16" }
 
 tokio = { version = "1.41.1", features = ["full"] }
 serde = { version = "1.0.215", features = ["derive"] }
@@ -18,8 +18,10 @@ thiserror = "2.0.12"
 url = { version = "2.5.3", features = ["default", "serde"] }
 
 tari_ootle_walletd_client = "0.29"
-tari_engine = "0.28"
-tari_engine_types = "0.28"
-tari_ootle_common_types = "0.28"
+tari_engine = "0.29"
+tari_engine_types = "0.29"
+tari_ootle_common_types = "0.29"
 tari_template_lib_types = "0.25"
 tari_ootle_template_metadata = "0.5"
+tari_ootle_wallet_sdk = "0.29"
+ootle_serde = "0.2"

--- a/README.md
+++ b/README.md
@@ -88,15 +88,22 @@ Run `tari --help` or `tari <command> --help` for full details.
 
 ## Configuration
 
-Project config lives in `tari.config.toml` (created by `tari config init` or the wizard):
+Project config lives in `tari.config.toml` (created by `tari config init` or the wizard) and is organised by network:
 
 ```toml
-[network]
-wallet-daemon-jrpc-address = "http://127.0.0.1:9000/json_rpc"
+default-network = "esmeralda"
+# default-account = "myaccount"
 
-# metadata-server-url = "http://localhost:3000"
-# default_account = "myaccount"
+[networks.esmeralda]
+wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
+metadata-server-url = "https://ootle-templates-esme.tari.com/"
+
+[networks.localnet]
+wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
+metadata-server-url = "http://localhost:3000/"
 ```
+
+Pass `-n/--network <name>` to override the active network on any command (e.g. `tari --network localnet publish`).
 
 Settings are resolved: **CLI flag > project config > global config > default**.
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 [dependencies]
 tari_ootle_publish_lib = { workspace = true }
 tari_ootle_template_metadata = { workspace = true, features = ["json"] }
+tari_ootle_common_types = { workspace = true }
 tari_engine_types = { workspace = true }
 
 anyhow = "1.0.102"

--- a/crates/cli/src/cli/command.rs
+++ b/crates/cli/src/cli/command.rs
@@ -25,6 +25,7 @@ use clap::{
 };
 use convert_case::{Case, Casing};
 use std::{env, path::PathBuf};
+use tari_ootle_common_types::Network;
 
 const DEFAULT_DATA_FOLDER_NAME: &str = "tari_cli";
 const TEMPLATE_REPOS_FOLDER_NAME: &str = "template_repositories";
@@ -83,6 +84,10 @@ pub fn project_name_parser(project_name: &str) -> Result<String, String> {
     Ok(project_name.to_case(Case::Snake))
 }
 
+fn parse_network(s: &str) -> Result<Network, String> {
+    s.parse().map_err(|e: tari_ootle_common_types::NetworkParseError| e.to_string())
+}
+
 #[derive(Clone, Debug)]
 pub struct ConfigOverride {
     pub key: String,
@@ -102,6 +107,11 @@ pub struct CommonArguments {
     /// Config file overrides
     #[arg(short = 'e', long, value_name = "KEY=VALUE", value_parser = config_override_parser)]
     config_overrides: Vec<ConfigOverride>,
+
+    /// Network to use. Overrides the default set in project and global config.
+    /// (e.g. `esmeralda`, `igor`, `localnet`, `mainnet`)
+    #[arg(short = 'n', long, value_name = "NETWORK", value_parser = parse_network, global = true)]
+    network: Option<Network>,
 }
 
 #[derive(Clone, Parser)]
@@ -269,15 +279,20 @@ impl Cli {
         // Commands that don't need template repository refresh
         match &command {
             Command::Template { .. } | Command::Publish { .. } | Command::Metadata { .. } => {
+                let network_override = self.args.network;
                 return match command {
                     Command::Template { command } => match command {
                         TemplateCommand::Init { args } => template::init_metadata::handle(args).await,
                         TemplateCommand::Inspect { args } => template::inspect_metadata::handle(args).await,
-                        TemplateCommand::Publish { args } => template::publish::handle(config, args).await,
+                        TemplateCommand::Publish { args } => {
+                            template::publish::handle(config, network_override, args).await
+                        },
                     },
-                    Command::Publish { args } => publish::handle(config, args).await,
+                    Command::Publish { args } => publish::handle(config, network_override, args).await,
                     Command::Metadata { command } => match command {
-                        MetadataCommand::Publish { args } => metadata::publish::handle(config, args).await,
+                        MetadataCommand::Publish { args } => {
+                            metadata::publish::handle(config, network_override, args).await
+                        },
                         MetadataCommand::Inspect { .. } => unreachable!(),
                     },
                     _ => unreachable!(),

--- a/crates/cli/src/cli/command.rs
+++ b/crates/cli/src/cli/command.rs
@@ -64,11 +64,9 @@ pub fn config_override_parser(config_override: &str) -> Result<ConfigOverride, S
         return Err(String::from("Override cannot be empty!"));
     }
 
-    let split: Vec<&str> = config_override.split("=").collect();
-    if split.len() != 2 {
-        return Err(String::from("Invalid override!"));
-    }
-    let (key, value) = (split.first().unwrap(), split.get(1).unwrap());
+    let Some((key, value)) = config_override.split_once('=') else {
+        return Err(String::from("Invalid override! Expected KEY=VALUE."));
+    };
 
     if !Config::is_override_key_valid(key) {
         return Err(format!("Override key invalid: {key}"));
@@ -78,6 +76,35 @@ pub fn config_override_parser(config_override: &str) -> Result<ConfigOverride, S
         key: key.to_string(),
         value: value.to_string(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn override_parser_accepts_nested_network_keys() {
+        let ov = config_override_parser("networks.esmeralda.wallet-daemon-url=http://localhost:5100/")
+            .expect("nested network key should parse");
+        assert_eq!(ov.key, "networks.esmeralda.wallet-daemon-url");
+        assert_eq!(ov.value, "http://localhost:5100/");
+    }
+
+    #[test]
+    fn override_parser_rejects_unknown_network() {
+        assert!(config_override_parser("networks.bogus.wallet-daemon-url=http://x").is_err());
+    }
+
+    #[test]
+    fn override_parser_rejects_unknown_field() {
+        assert!(config_override_parser("networks.esmeralda.bogus=http://x").is_err());
+    }
+
+    #[test]
+    fn override_parser_keeps_value_with_equals() {
+        let ov = config_override_parser("default_account=acc=ount").expect("split_once should keep tail intact");
+        assert_eq!(ov.value, "acc=ount");
+    }
 }
 
 pub fn project_name_parser(project_name: &str) -> Result<String, String> {

--- a/crates/cli/src/cli/command.rs
+++ b/crates/cli/src/cli/command.rs
@@ -85,7 +85,8 @@ pub fn project_name_parser(project_name: &str) -> Result<String, String> {
 }
 
 fn parse_network(s: &str) -> Result<Network, String> {
-    s.parse().map_err(|e: tari_ootle_common_types::NetworkParseError| e.to_string())
+    s.parse()
+        .map_err(|e: tari_ootle_common_types::NetworkParseError| e.to_string())
 }
 
 #[derive(Clone, Debug)]

--- a/crates/cli/src/cli/commands/config.rs
+++ b/crates/cli/src/cli/commands/config.rs
@@ -136,30 +136,46 @@ pub fn find_repo_root() -> Option<PathBuf> {
 
 fn set_dotted_key(doc: &mut toml_edit::DocumentMut, key: &str, value: &str) -> anyhow::Result<()> {
     let parts: Vec<&str> = key.split('.').collect();
-    match parts.len() {
-        1 => {
-            doc.insert(parts[0], toml_edit::value(value));
-        },
-        2 => {
-            let table = doc
-                .entry(parts[0])
-                .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()))
-                .as_table_mut()
-                .ok_or_else(|| anyhow!("'{key}' is not a table"))?;
-            table.insert(parts[1], toml_edit::value(value));
-        },
-        _ => return Err(anyhow!("Unsupported key depth: {key}")),
+    if parts.is_empty() {
+        return Err(anyhow!("Empty key"));
     }
+
+    if parts.len() == 1 {
+        doc.insert(parts[0], toml_edit::value(value));
+        return Ok(());
+    }
+
+    // Walk/create intermediate tables, then insert the leaf.
+    let (leaf, head) = parts.split_last().expect("non-empty parts");
+    let root = doc
+        .entry(head[0])
+        .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()))
+        .as_table_mut()
+        .ok_or_else(|| anyhow!("'{}' is not a table", head[0]))?;
+
+    let mut table = root;
+    for part in &head[1..] {
+        let entry = table
+            .entry(part)
+            .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
+        table = entry
+            .as_table_mut()
+            .ok_or_else(|| anyhow!("'{part}' is not a table"))?;
+    }
+    table.insert(leaf, toml_edit::value(value));
     Ok(())
 }
 
 fn get_dotted_key(doc: &toml_edit::DocumentMut, key: &str) -> anyhow::Result<String> {
     let parts: Vec<&str> = key.split('.').collect();
-    let item = match parts.len() {
-        1 => doc.get(parts[0]),
-        2 => doc.get(parts[0]).and_then(|t| t.get(parts[1])),
-        _ => return Err(anyhow!("Unsupported key depth: {key}")),
-    };
+    if parts.is_empty() {
+        return Err(anyhow!("Empty key"));
+    }
+
+    let mut item: Option<&toml_edit::Item> = doc.get(parts[0]);
+    for part in &parts[1..] {
+        item = item.and_then(|i| i.get(part));
+    }
 
     match item {
         Some(toml_edit::Item::Value(v)) => {
@@ -167,7 +183,7 @@ fn get_dotted_key(doc: &toml_edit::DocumentMut, key: &str) -> anyhow::Result<Str
             Ok(s.trim().trim_matches('"').to_string())
         },
         Some(toml_edit::Item::Table(t)) => Ok(t.to_string()),
-        Some(_) => Ok(item.unwrap().to_string()),
+        Some(other) => Ok(other.to_string()),
         None => Err(anyhow!("Key '{key}' not found")),
     }
 }

--- a/crates/cli/src/cli/commands/config.rs
+++ b/crates/cli/src/cli/commands/config.rs
@@ -158,9 +158,7 @@ fn set_dotted_key(doc: &mut toml_edit::DocumentMut, key: &str, value: &str) -> a
         let entry = table
             .entry(part)
             .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
-        table = entry
-            .as_table_mut()
-            .ok_or_else(|| anyhow!("'{part}' is not a table"))?;
+        table = entry.as_table_mut().ok_or_else(|| anyhow!("'{part}' is not a table"))?;
     }
     table.insert(leaf, toml_edit::value(value));
     Ok(())

--- a/crates/cli/src/cli/commands/config.rs
+++ b/crates/cli/src/cli/commands/config.rs
@@ -134,10 +134,14 @@ pub fn find_repo_root() -> Option<PathBuf> {
     }
 }
 
-fn set_dotted_key(doc: &mut toml_edit::DocumentMut, key: &str, value: &str) -> anyhow::Result<()> {
+/// Set an arbitrary dotted-path key in a TOML document.
+///
+/// Intermediate tables (anything except the leaf-holding table) are marked implicit so nested
+/// structures render as `[a.b]` instead of `[a]\n[a.b]`.
+pub fn set_dotted_key(doc: &mut toml_edit::DocumentMut, key: &str, value: &str) -> anyhow::Result<()> {
     let parts: Vec<&str> = key.split('.').collect();
-    if parts.is_empty() {
-        return Err(anyhow!("Empty key"));
+    if parts.is_empty() || parts.iter().any(|p| p.is_empty()) {
+        return Err(anyhow!("Empty or malformed key: '{key}'"));
     }
 
     if parts.len() == 1 {
@@ -153,12 +157,22 @@ fn set_dotted_key(doc: &mut toml_edit::DocumentMut, key: &str, value: &str) -> a
         .as_table_mut()
         .ok_or_else(|| anyhow!("'{}' is not a table", head[0]))?;
 
+    // Any table we traverse *through* (i.e. not the table holding the leaf) only contains
+    // sub-tables, so render it implicit.
+    if head.len() > 1 {
+        root.set_implicit(true);
+    }
+
+    let last_idx = head.len().saturating_sub(2); // index in head[1..] of the leaf-holding table
     let mut table = root;
-    for part in &head[1..] {
+    for (i, part) in head[1..].iter().enumerate() {
         let entry = table
             .entry(part)
             .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
         table = entry.as_table_mut().ok_or_else(|| anyhow!("'{part}' is not a table"))?;
+        if i < last_idx {
+            table.set_implicit(true);
+        }
     }
     table.insert(leaf, toml_edit::value(value));
     Ok(())

--- a/crates/cli/src/cli/commands/metadata/publish.rs
+++ b/crates/cli/src/cli/commands/metadata/publish.rs
@@ -4,13 +4,17 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use crate::cli::commands::publish::{find_metadata_cbor, load_project_config};
+use crate::cli::commands::publish::{
+    find_metadata_cbor, load_project_config, resolve_active_network, resolve_wallet_daemon_url,
+};
 use crate::cli::config::Config;
 use crate::cli::util::get_default_metadata_server_url;
 use anyhow::{Context, anyhow};
 use clap::Parser;
 use dialoguer::Confirm;
 use tari_engine_types::published_template::PublishedTemplateAddress;
+use tari_ootle_common_types::Network;
+use tari_ootle_publish_lib::NetworkConfig;
 use tari_ootle_publish_lib::publisher::{SignedMetadataPayload, TemplatePublisher};
 use tari_ootle_template_metadata::TemplateMetadata;
 use url::Url;
@@ -57,36 +61,36 @@ pub struct PublishMetadataArgs {
     pub wallet_daemon_url: Option<url::Url>,
 }
 
-pub async fn handle(config: Config, args: PublishMetadataArgs) -> anyhow::Result<()> {
+pub async fn handle(
+    config: Config,
+    network_override: Option<Network>,
+    args: PublishMetadataArgs,
+) -> anyhow::Result<()> {
     let cbor_path = find_metadata_cbor(&args.path).await?;
     let mut cbor_bytes = std::fs::read(&cbor_path).context("reading metadata CBOR file")?;
 
-    let url_override = args.wallet_daemon_url.as_ref().or(config.wallet_daemon_url.as_ref());
-    let project_config = load_project_config(&args.path, url_override).await?;
+    let project_config = load_project_config(&args.path).await?;
+    let network = resolve_active_network(network_override, &project_config, &config);
+    let wallet_daemon_url =
+        resolve_wallet_daemon_url(args.wallet_daemon_url.as_ref(), &project_config, &config, network);
+    println!("🌐 Network: {network}");
 
-    let publisher = TemplatePublisher::new(project_config.network().clone());
+    let publisher = TemplatePublisher::new(NetworkConfig::new(wallet_daemon_url));
 
-    // Resolve metadata server URL: CLI flag > project config > global config > default
+    // Resolve metadata server URL: CLI flag > project config > global config > default for network
     let metadata_server_url = args
         .metadata_server_url
         .as_ref()
-        .or(project_config.metadata_server_url())
-        .or(config.metadata_server_url.as_ref())
+        .or(project_config.metadata_server_url(network))
+        .or(config.metadata_server_url(network))
         .cloned();
 
     let metadata_server_url = match metadata_server_url {
         Some(url) => url,
         None => {
-            let resp = publisher
-                .wallet_daemon_client()
-                .await?
-                .get_settings()
-                .await
-                .context("fetching network settings from wallet daemon")?;
-            let default_url = get_default_metadata_server_url(&resp.network.name)
-                .ok_or_else(|| anyhow!("no default metadata server for {}", resp.network.name))?;
-            let default_url: Url = default_url.parse().expect("parse default url");
-            default_url
+            let default_url = get_default_metadata_server_url(network)
+                .ok_or_else(|| anyhow!("no default metadata server for {network}"))?;
+            default_url.parse::<Url>().expect("parse default url")
         },
     };
 
@@ -118,13 +122,14 @@ pub async fn handle(config: Config, args: PublishMetadataArgs) -> anyhow::Result
         }
     }
 
-    // Resolve template address: CLI flag > project config
+    // Resolve template address: CLI flag > project config for selected network
     let addr = args
         .template_address
-        .or_else(|| project_config.template_address().cloned())
+        .or_else(|| project_config.template_address(network).cloned())
         .ok_or_else(|| {
             anyhow!(
-                "No template address provided. Use --template-address or publish the template first \
+                "No template address provided for network '{network}'. \
+                 Use --template-address or publish the template first \
                  (`tari publish`) to save the address in tari.config.toml."
             )
         })?;

--- a/crates/cli/src/cli/commands/publish.rs
+++ b/crates/cli/src/cli/commands/publish.rs
@@ -10,6 +10,7 @@ use cargo_toml::Manifest;
 use clap::Parser;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use tari_ootle_common_types::Network;
 use tari_ootle_publish_lib::walletd_client::ComponentAddressOrName;
 use tokio::fs;
 use tokio::process::Command;
@@ -84,7 +85,7 @@ pub async fn build_template(crate_dir: &Path) -> anyhow::Result<PathBuf> {
 }
 
 /// `tari publish` delegates to `tari template publish` — they behave identically.
-pub async fn handle(config: Config, args: PublishArgs) -> anyhow::Result<()> {
+pub async fn handle(config: Config, network_override: Option<Network>, args: PublishArgs) -> anyhow::Result<()> {
     let template_args = TemplatePublishArgs {
         path: args.path,
         account: args.account,
@@ -96,7 +97,7 @@ pub async fn handle(config: Config, args: PublishArgs) -> anyhow::Result<()> {
         publish_metadata: args.publish_metadata,
         metadata_server_url: args.metadata_server_url,
     };
-    crate::cli::commands::template::publish::handle(config, template_args).await
+    crate::cli::commands::template::publish::handle(config, network_override, template_args).await
 }
 
 async fn build_project(dir: &Path, name: &str) -> anyhow::Result<PathBuf> {
@@ -199,44 +200,53 @@ pub async fn find_metadata_cbor(project_dir: &Path) -> anyhow::Result<PathBuf> {
     })
 }
 
-pub async fn load_project_config(
-    project_folder: &Path,
-    wallet_daemon_url_override: Option<&url::Url>,
-) -> anyhow::Result<project::ProjectConfig> {
+pub async fn load_project_config(project_folder: &Path) -> anyhow::Result<project::ProjectConfig> {
     // Search current dir and parents for tari.config.toml
-    let mut config = None;
     let mut search_dir = project_folder.to_path_buf();
     loop {
         let config_file = search_dir.join(project::CONFIG_FILE_NAME);
         if config_file.exists() {
-            config = Some(
-                toml::from_str::<project::ProjectConfig>(
-                    fs::read_to_string(&config_file)
-                        .await
-                        .map_err(|error| {
-                            anyhow!(
-                                "Failed to load project config file (at {}): {}",
-                                config_file.display(),
-                                error
-                            )
-                        })?
-                        .as_str(),
+            let content = fs::read_to_string(&config_file).await.map_err(|error| {
+                anyhow!(
+                    "Failed to load project config file (at {}): {}",
+                    config_file.display(),
+                    error
                 )
-                .context("parsing config toml")?,
-            );
-            break;
+            })?;
+            return toml::from_str::<project::ProjectConfig>(content.as_str()).context("parsing config toml");
         }
         if !search_dir.pop() {
             break;
         }
     }
 
-    let mut config = config.unwrap_or_default();
+    Ok(project::ProjectConfig::default())
+}
 
-    // CLI flag overrides everything
-    if let Some(url) = wallet_daemon_url_override {
-        config.set_wallet_daemon_url(url.clone());
-    }
+/// Resolve the active network: CLI flag > project default > global default > Esmeralda.
+pub fn resolve_active_network(
+    cli_override: Option<Network>,
+    project: &project::ProjectConfig,
+    global: &Config,
+) -> Network {
+    cli_override
+        .or_else(|| project.default_network())
+        .or(global.default_network)
+        .unwrap_or_default()
+}
 
-    Ok(config)
+/// Resolve wallet-daemon URL for the active network. Precedence: CLI flag > project > global > default.
+pub fn resolve_wallet_daemon_url(
+    cli_override: Option<&url::Url>,
+    project: &project::ProjectConfig,
+    global: &Config,
+    network: Network,
+) -> url::Url {
+    cli_override
+        .cloned()
+        .or_else(|| project.wallet_daemon_url(network).cloned())
+        .or_else(|| global.wallet_daemon_url(network).cloned())
+        .unwrap_or_else(|| {
+            url::Url::parse(project::DEFAULT_WALLET_DAEMON_URL).expect("default wallet daemon URL is valid")
+        })
 }

--- a/crates/cli/src/cli/commands/template/publish.rs
+++ b/crates/cli/src/cli/commands/template/publish.rs
@@ -8,12 +8,16 @@ use anyhow::{Context, anyhow};
 use clap::Parser;
 use dialoguer::Confirm;
 use tari_engine_types::published_template::PublishedTemplateAddress;
+use tari_ootle_common_types::Network;
+use tari_ootle_publish_lib::NetworkConfig;
 use tari_ootle_publish_lib::publisher::{CheckBalanceResult, Template, TemplatePublisher};
 use tari_ootle_publish_lib::walletd_client::ComponentAddressOrName;
 use tari_ootle_template_metadata::TemplateMetadata;
 
 use crate::cli::commands::metadata::publish::publish_metadata_to_server;
-use crate::cli::commands::publish::{build_template, find_metadata_cbor, load_project_config};
+use crate::cli::commands::publish::{
+    build_template, find_metadata_cbor, load_project_config, resolve_active_network, resolve_wallet_daemon_url,
+};
 use crate::cli::config::Config;
 use crate::cli::util;
 use crate::cli::util::get_default_metadata_server_url;
@@ -63,14 +67,21 @@ pub struct TemplatePublishArgs {
     pub metadata_server_url: Option<url::Url>,
 }
 
-pub async fn handle(config: Config, mut args: TemplatePublishArgs) -> anyhow::Result<()> {
+pub async fn handle(
+    config: Config,
+    network_override: Option<Network>,
+    mut args: TemplatePublishArgs,
+) -> anyhow::Result<()> {
     let crate_dir = &args.path;
 
-    let url_override = args.wallet_daemon_url.as_ref().or(config.wallet_daemon_url.as_ref());
-    let project_config = load_project_config(crate_dir, url_override).await?;
+    let project_config = load_project_config(crate_dir).await?;
+    let network = resolve_active_network(network_override, &project_config, &config);
+    let wallet_daemon_url =
+        resolve_wallet_daemon_url(args.wallet_daemon_url.as_ref(), &project_config, &config, network);
+    println!("🌐 Network: {network}");
 
     // Warn if template address already exists in config (republishing)
-    if let Some(existing_addr) = project_config.template_address() {
+    if let Some(existing_addr) = project_config.template_address(network) {
         println!("⚠️  A template has already been published from this project: {existing_addr}");
         println!("   If the template binary is unchanged, the transaction will fail.");
         println!("   If changed, a new template address will be generated.");
@@ -130,15 +141,13 @@ pub async fn handle(config: Config, mut args: TemplatePublishArgs) -> anyhow::Re
     };
 
     // Connect to wallet daemon
-    let publisher = TemplatePublisher::new(project_config.network().clone());
-    let info = publisher.get_wallet_info().await.with_context(|| {
-        anyhow!(
-            "Failed to connect to the wallet at {}",
-            project_config.network().wallet_daemon_jrpc_address(),
-        )
-    })?;
+    let publisher = TemplatePublisher::new(NetworkConfig::new(wallet_daemon_url.clone()));
+    let info = publisher
+        .get_wallet_info()
+        .await
+        .with_context(|| anyhow!("Failed to connect to the wallet at {}", wallet_daemon_url))?;
     println!(
-        "🔗 Connected to wallet version {} (network: {})",
+        "🔗 Connected to wallet version {} (wallet network: {})",
         info.version, info.network
     );
 
@@ -176,14 +185,14 @@ pub async fn handle(config: Config, mut args: TemplatePublishArgs) -> anyhow::Re
     let published_addr = PublishedTemplateAddress::from_template_address(template_address);
     println!("⭐ Your new template's address: {published_addr}");
 
-    // Save template address to project config
+    // Save template address to project config under [networks.<network>]
     let config_path = crate::cli::commands::config::resolve_config_path()?;
     if config_path.exists() {
         let content = tokio::fs::read_to_string(&config_path)
             .await
             .context("reading config")?;
         let mut doc = content.parse::<toml_edit::DocumentMut>().context("parsing config")?;
-        doc.insert("template-address", toml_edit::value(published_addr.to_string()));
+        save_template_address(&mut doc, network, &published_addr.to_string());
         tokio::fs::write(&config_path, doc.to_string())
             .await
             .context("writing config")?;
@@ -210,19 +219,18 @@ pub async fn handle(config: Config, mut args: TemplatePublishArgs) -> anyhow::Re
         let cbor_path = find_metadata_cbor(crate_dir).await?;
         let cbor_bytes = std::fs::read(&cbor_path).context("reading metadata CBOR for server publish")?;
 
-        let resolved_default = get_default_metadata_server_url(&info.network)
+        let resolved_default = get_default_metadata_server_url(network)
             .map(|s| s.parse::<url::Url>().expect("parse default metadata server url"));
         let metadata_server_url = args
             .metadata_server_url
             .as_ref()
-            .or(project_config.metadata_server_url())
-            .or(config.metadata_server_url.as_ref())
+            .or(project_config.metadata_server_url(network))
+            .or(config.metadata_server_url(network))
             .or(resolved_default.as_ref())
             .ok_or_else(|| {
                 anyhow!(
-                    "No metadata server URL configured and no default known for network '{}'. \
-                     Pass --metadata-server-url or set it in tari.config.toml.",
-                    info.network
+                    "No metadata server URL configured and no default known for network '{network}'. \
+                     Pass --metadata-server-url or set it in tari.config.toml."
                 )
             })?;
 
@@ -239,6 +247,30 @@ pub async fn handle(config: Config, mut args: TemplatePublishArgs) -> anyhow::Re
     }
 
     Ok(())
+}
+
+fn save_template_address(doc: &mut toml_edit::DocumentMut, network: Network, address: &str) {
+    let networks = doc
+        .entry("networks")
+        .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
+    let Some(networks_table) = networks.as_table_mut() else {
+        // Not a table — overwrite.
+        *networks = toml_edit::Item::Table(toml_edit::Table::new());
+        return save_template_address(doc, network, address);
+    };
+    networks_table.set_implicit(true);
+
+    let net_entry = networks_table
+        .entry(network.as_key_str())
+        .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
+    let net_table = match net_entry.as_table_mut() {
+        Some(t) => t,
+        None => {
+            *net_entry = toml_edit::Item::Table(toml_edit::Table::new());
+            net_entry.as_table_mut().unwrap()
+        },
+    };
+    net_table.insert("template-address", toml_edit::value(address.to_string()));
 }
 
 async fn resolve_account(

--- a/crates/cli/src/cli/commands/template/publish.rs
+++ b/crates/cli/src/cli/commands/template/publish.rs
@@ -151,6 +151,14 @@ pub async fn handle(
         info.version, info.network
     );
 
+    if info.network_byte != network.as_byte() {
+        return Err(anyhow!(
+            "Wallet daemon is on network '{}' but the CLI is configured for '{network}'. \
+             Use --network <name> to switch, or point --wallet-daemon-url at a daemon for the right network.",
+            info.network
+        ));
+    }
+
     let account = resolve_account(&args, &config, &publisher, &project_config).await?;
     let template = Template::Path { path: template_bin };
 
@@ -192,7 +200,11 @@ pub async fn handle(
             .await
             .context("reading config")?;
         let mut doc = content.parse::<toml_edit::DocumentMut>().context("parsing config")?;
-        save_template_address(&mut doc, network, &published_addr.to_string());
+        crate::cli::commands::config::set_dotted_key(
+            &mut doc,
+            &format!("networks.{}.template-address", network.as_key_str()),
+            &published_addr.to_string(),
+        )?;
         tokio::fs::write(&config_path, doc.to_string())
             .await
             .context("writing config")?;
@@ -247,30 +259,6 @@ pub async fn handle(
     }
 
     Ok(())
-}
-
-fn save_template_address(doc: &mut toml_edit::DocumentMut, network: Network, address: &str) {
-    let networks = doc
-        .entry("networks")
-        .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
-    let Some(networks_table) = networks.as_table_mut() else {
-        // Not a table — overwrite.
-        *networks = toml_edit::Item::Table(toml_edit::Table::new());
-        return save_template_address(doc, network, address);
-    };
-    networks_table.set_implicit(true);
-
-    let net_entry = networks_table
-        .entry(network.as_key_str())
-        .or_insert_with(|| toml_edit::Item::Table(toml_edit::Table::new()));
-    let net_table = match net_entry.as_table_mut() {
-        Some(t) => t,
-        None => {
-            *net_entry = toml_edit::Item::Table(toml_edit::Table::new());
-            net_entry.as_table_mut().unwrap()
-        },
-    };
-    net_table.insert("template-address", toml_edit::value(address.to_string()));
 }
 
 async fn resolve_account(

--- a/crates/cli/src/cli/commands/wizard.rs
+++ b/crates/cli/src/cli/commands/wizard.rs
@@ -118,15 +118,16 @@ async fn step_project_config(_crate_dir: &PathBuf) -> anyhow::Result<()> {
         .context("writing config file")?;
     println!("✅ Created {}", config_path.display());
 
-    // Ask for wallet daemon URL
+    // Ask for wallet daemon URL (applied to the default network: esmeralda)
+    let default_url = crate::project::DEFAULT_WALLET_DAEMON_URL.to_string();
     let url: String = Input::new()
-        .with_prompt("Wallet daemon JSON-RPC URL")
-        .default("http://127.0.0.1:5100/json_rpc".to_string())
+        .with_prompt("Wallet daemon JSON-RPC URL (for esmeralda)")
+        .default(default_url.clone())
         .interact_text()?;
 
-    if url != "http://127.0.0.1:5100/json_rpc" {
+    if url != default_url {
         crate::cli::commands::config::handle(ConfigCommand::Set {
-            key: "network.wallet-daemon-jrpc-address".to_string(),
+            key: "networks.esmeralda.wallet-daemon-url".to_string(),
             value: url,
         })
         .await?;

--- a/crates/cli/src/cli/config.rs
+++ b/crates/cli/src/cli/config.rs
@@ -1,20 +1,23 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use std::collections::HashMap;
 use std::{path::PathBuf, string::ToString};
 
 use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
+use tari_ootle_common_types::Network;
 use tari_ootle_publish_lib::walletd_client::ComponentAddressOrName;
 use tokio::{fs, io::AsyncWriteExt};
+
+use crate::project::DEFAULT_WALLET_DAEMON_URL;
 
 pub const VALID_OVERRIDE_KEYS: &[&str] = &[
     "template_repository.url",
     "template_repository.branch",
     "template_repository.folder",
     "default_account",
-    "wallet_daemon_url",
-    "metadata_server_url",
+    "default_network",
 ];
 
 /// CLI configuration.
@@ -23,10 +26,19 @@ pub const VALID_OVERRIDE_KEYS: &[&str] = &[
 pub struct Config {
     pub template_repository: TemplateRepository,
     pub default_account: Option<ComponentAddressOrName>,
-    /// Global default wallet daemon JSON-RPC URL.
-    /// Used when no tari.config.toml is found in the project tree.
+    /// Default network used when no project config or CLI flag selects one.
+    pub default_network: Option<Network>,
+    /// Per-network defaults (wallet daemon URL, metadata server URL).
+    #[serde(default)]
+    pub networks: HashMap<Network, CliNetworkSettings>,
+}
+
+/// Per-network CLI defaults used when the project config is absent or does not
+/// specify a value for the selected network.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct CliNetworkSettings {
     pub wallet_daemon_url: Option<url::Url>,
-    /// Default metadata server URL for publishing template metadata.
     pub metadata_server_url: Option<url::Url>,
 }
 
@@ -41,6 +53,14 @@ pub struct TemplateRepository {
 
 impl Default for Config {
     fn default() -> Self {
+        let mut networks = HashMap::new();
+        networks.insert(
+            Network::Esmeralda,
+            CliNetworkSettings {
+                wallet_daemon_url: Some(url::Url::parse(DEFAULT_WALLET_DAEMON_URL).expect("default URL is valid")),
+                metadata_server_url: None,
+            },
+        );
         Self {
             template_repository: TemplateRepository {
                 url: "https://github.com/tari-project/wasm-template".to_string(),
@@ -48,8 +68,8 @@ impl Default for Config {
                 folder: "wasm_templates".to_string(),
             },
             default_account: None,
-            wallet_daemon_url: None,
-            metadata_server_url: None,
+            default_network: Some(Network::Esmeralda),
+            networks,
         }
     }
 }
@@ -77,6 +97,14 @@ impl Config {
         VALID_OVERRIDE_KEYS.contains(&key)
     }
 
+    pub fn wallet_daemon_url(&self, network: Network) -> Option<&url::Url> {
+        self.networks.get(&network).and_then(|n| n.wallet_daemon_url.as_ref())
+    }
+
+    pub fn metadata_server_url(&self, network: Network) -> Option<&url::Url> {
+        self.networks.get(&network).and_then(|n| n.metadata_server_url.as_ref())
+    }
+
     pub fn override_data(&mut self, key: &str, value: &str) -> anyhow::Result<&mut Self> {
         if !Self::is_override_key_valid(key) {
             return Err(anyhow!("Invalid key: {}", key));
@@ -95,11 +123,8 @@ impl Config {
             "default_account" => {
                 self.default_account = Some(value.parse()?);
             },
-            "wallet_daemon_url" => {
-                self.wallet_daemon_url = Some(value.parse().map_err(|e| anyhow!("Invalid URL: {e}"))?);
-            },
-            "metadata_server_url" => {
-                self.metadata_server_url = Some(value.parse().map_err(|e| anyhow!("Invalid URL: {e}"))?);
+            "default_network" => {
+                self.default_network = Some(value.parse().map_err(|e| anyhow!("Invalid network: {e}"))?);
             },
             _ => {},
         }

--- a/crates/cli/src/cli/config.rs
+++ b/crates/cli/src/cli/config.rs
@@ -22,6 +22,8 @@ pub const VALID_OVERRIDE_KEYS: &[&str] = &[
     "default_network",
 ];
 
+const VALID_NETWORK_OVERRIDE_FIELDS: &[&str] = &["wallet-daemon-url", "metadata-server-url"];
+
 /// CLI configuration.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
@@ -106,7 +108,15 @@ impl Config {
     }
 
     pub fn is_override_key_valid(key: &str) -> bool {
-        VALID_OVERRIDE_KEYS.contains(&key)
+        if VALID_OVERRIDE_KEYS.contains(&key) {
+            return true;
+        }
+        // networks.<net>.<wallet-daemon-url|metadata-server-url>
+        let parts: Vec<&str> = key.split('.').collect();
+        if parts.len() == 3 && parts[0] == "networks" {
+            return parts[1].parse::<Network>().is_ok() && VALID_NETWORK_OVERRIDE_FIELDS.contains(&parts[2]);
+        }
+        false
     }
 
     pub fn wallet_daemon_url(&self, network: Network) -> Option<&url::Url> {
@@ -138,9 +148,23 @@ impl Config {
             "default_network" => {
                 self.default_network = Some(value.parse().map_err(|e| anyhow!("Invalid network: {e}"))?);
             },
-            _ => {},
+            _ => self.apply_network_override(key, value)?,
         }
 
         Ok(self)
+    }
+
+    fn apply_network_override(&mut self, key: &str, value: &str) -> anyhow::Result<()> {
+        let parts: Vec<&str> = key.split('.').collect();
+        // is_override_key_valid already enforced shape and Network parse.
+        let network: Network = parts[1].parse().map_err(|e| anyhow!("Invalid network: {e}"))?;
+        let entry = self.networks.entry(network).or_default();
+        let url: url::Url = value.parse().map_err(|e| anyhow!("Invalid URL: {e}"))?;
+        match parts[2] {
+            "wallet-daemon-url" => entry.wallet_daemon_url = Some(url),
+            "metadata-server-url" => entry.metadata_server_url = Some(url),
+            other => return Err(anyhow!("Unknown network field: {other}")),
+        }
+        Ok(())
     }
 }

--- a/crates/cli/src/cli/config.rs
+++ b/crates/cli/src/cli/config.rs
@@ -10,7 +10,9 @@ use tari_ootle_common_types::Network;
 use tari_ootle_publish_lib::walletd_client::ComponentAddressOrName;
 use tokio::{fs, io::AsyncWriteExt};
 
-use crate::project::DEFAULT_WALLET_DAEMON_URL;
+use crate::project::{
+    DEFAULT_METADATA_SERVER_URL_ESMERALDA, DEFAULT_METADATA_SERVER_URL_LOCALNET, DEFAULT_WALLET_DAEMON_URL,
+};
 
 pub const VALID_OVERRIDE_KEYS: &[&str] = &[
     "template_repository.url",
@@ -53,21 +55,22 @@ pub struct TemplateRepository {
 
 impl Default for Config {
     fn default() -> Self {
-        let default_url =
+        let wallet_url =
             || Some(url::Url::parse(DEFAULT_WALLET_DAEMON_URL).expect("default wallet daemon URL is valid"));
+        let metadata_url = |s: &str| Some(url::Url::parse(s).expect("default metadata server URL is valid"));
         let mut networks = HashMap::new();
         networks.insert(
             Network::Esmeralda,
             CliNetworkSettings {
-                wallet_daemon_url: default_url(),
-                metadata_server_url: None,
+                wallet_daemon_url: wallet_url(),
+                metadata_server_url: metadata_url(DEFAULT_METADATA_SERVER_URL_ESMERALDA),
             },
         );
         networks.insert(
             Network::LocalNet,
             CliNetworkSettings {
-                wallet_daemon_url: default_url(),
-                metadata_server_url: None,
+                wallet_daemon_url: wallet_url(),
+                metadata_server_url: metadata_url(DEFAULT_METADATA_SERVER_URL_LOCALNET),
             },
         );
         Self {

--- a/crates/cli/src/cli/config.rs
+++ b/crates/cli/src/cli/config.rs
@@ -53,11 +53,20 @@ pub struct TemplateRepository {
 
 impl Default for Config {
     fn default() -> Self {
+        let default_url =
+            || Some(url::Url::parse(DEFAULT_WALLET_DAEMON_URL).expect("default wallet daemon URL is valid"));
         let mut networks = HashMap::new();
         networks.insert(
             Network::Esmeralda,
             CliNetworkSettings {
-                wallet_daemon_url: Some(url::Url::parse(DEFAULT_WALLET_DAEMON_URL).expect("default URL is valid")),
+                wallet_daemon_url: default_url(),
+                metadata_server_url: None,
+            },
+        );
+        networks.insert(
+            Network::LocalNet,
+            CliNetworkSettings {
+                wallet_daemon_url: default_url(),
                 metadata_server_url: None,
             },
         );

--- a/crates/cli/src/cli/util.rs
+++ b/crates/cli/src/cli/util.rs
@@ -4,6 +4,7 @@
 use std::{fs::Metadata, io, path::PathBuf};
 
 use dialoguer::FuzzySelect;
+use tari_ootle_common_types::Network;
 use tokio::fs;
 
 pub async fn create_dir(dir: &PathBuf) -> io::Result<()> {
@@ -36,10 +37,10 @@ pub fn human_bytes(n: usize) -> String {
     human_bytes::human_bytes(n as f64)
 }
 
-pub fn get_default_metadata_server_url(network: &str) -> Option<&'static str> {
+pub fn get_default_metadata_server_url(network: Network) -> Option<&'static str> {
     match network {
-        "localnet" => Some("http://localhost:3000"),
-        "esmeralda" => Some("https://ootle-templates-esme.tari.com/"),
+        Network::LocalNet => Some("http://localhost:3000"),
+        Network::Esmeralda => Some("https://ootle-templates-esme.tari.com/"),
         _ => None,
     }
 }

--- a/crates/cli/src/cli/util.rs
+++ b/crates/cli/src/cli/util.rs
@@ -39,8 +39,8 @@ pub fn human_bytes(n: usize) -> String {
 
 pub fn get_default_metadata_server_url(network: Network) -> Option<&'static str> {
     match network {
-        Network::LocalNet => Some("http://localhost:3000"),
-        Network::Esmeralda => Some("https://ootle-templates-esme.tari.com/"),
+        Network::LocalNet => Some(crate::project::DEFAULT_METADATA_SERVER_URL_LOCALNET),
+        Network::Esmeralda => Some(crate::project::DEFAULT_METADATA_SERVER_URL_ESMERALDA),
         _ => None,
     }
 }

--- a/crates/cli/src/project/config.rs
+++ b/crates/cli/src/project/config.rs
@@ -1,40 +1,50 @@
 // Copyright 2024 The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use tari_engine_types::published_template::PublishedTemplateAddress;
-use tari_ootle_publish_lib::NetworkConfig;
+use tari_ootle_common_types::Network;
 use tari_ootle_publish_lib::walletd_client::ComponentAddressOrName;
 use url::Url;
+
+pub const DEFAULT_WALLET_DAEMON_URL: &str = "http://127.0.0.1:5100/json_rpc";
 
 /// Project configuration.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ProjectConfig {
-    network: NetworkConfig,
+    default_network: Option<Network>,
     default_account: Option<String>,
-    /// Metadata server URL for publishing template metadata.
-    metadata_server_url: Option<url::Url>,
-    /// Template address from the most recent publish.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    template_address: Option<PublishedTemplateAddress>,
+    #[serde(default)]
+    networks: HashMap<Network, ProjectNetworkSettings>,
+}
+
+/// Per-network project settings.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ProjectNetworkSettings {
+    pub wallet_daemon_url: Option<Url>,
+    pub metadata_server_url: Option<Url>,
+    pub template_address: Option<PublishedTemplateAddress>,
 }
 
 impl ProjectConfig {
-    pub fn network(&self) -> &NetworkConfig {
-        &self.network
+    pub fn default_network(&self) -> Option<Network> {
+        self.default_network
     }
 
-    pub fn set_wallet_daemon_url(&mut self, url: Url) {
-        self.network = NetworkConfig::new(url);
+    pub fn wallet_daemon_url(&self, network: Network) -> Option<&Url> {
+        self.networks.get(&network).and_then(|n| n.wallet_daemon_url.as_ref())
     }
 
-    pub fn metadata_server_url(&self) -> Option<&url::Url> {
-        self.metadata_server_url.as_ref()
+    pub fn metadata_server_url(&self, network: Network) -> Option<&Url> {
+        self.networks.get(&network).and_then(|n| n.metadata_server_url.as_ref())
     }
 
-    pub fn template_address(&self) -> Option<&PublishedTemplateAddress> {
-        self.template_address.as_ref()
+    pub fn template_address(&self, network: Network) -> Option<&PublishedTemplateAddress> {
+        self.networks.get(&network).and_then(|n| n.template_address.as_ref())
     }
 
     pub fn parsed_default_account(&self) -> anyhow::Result<Option<ComponentAddressOrName>> {
@@ -45,11 +55,62 @@ impl ProjectConfig {
 
 impl Default for ProjectConfig {
     fn default() -> Self {
+        let mut networks = HashMap::new();
+        networks.insert(
+            Network::Esmeralda,
+            ProjectNetworkSettings {
+                wallet_daemon_url: Some(Url::parse(DEFAULT_WALLET_DAEMON_URL).expect("default URL is valid")),
+                metadata_server_url: None,
+                template_address: None,
+            },
+        );
         Self {
-            network: NetworkConfig::new(Url::parse("http://127.0.0.1:5100/json_rpc").unwrap()),
+            default_network: Some(Network::Esmeralda),
             default_account: None,
-            metadata_server_url: None,
-            template_address: None,
+            networks,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_project_config_roundtrips() {
+        let cfg = ProjectConfig::default();
+        let ser = toml::to_string(&cfg).expect("serialize default");
+        let de: ProjectConfig = toml::from_str(&ser).expect("deserialize default");
+        assert_eq!(de.default_network(), Some(Network::Esmeralda));
+        assert_eq!(
+            de.wallet_daemon_url(Network::Esmeralda).map(|u| u.as_str()),
+            Some(DEFAULT_WALLET_DAEMON_URL)
+        );
+    }
+
+    #[test]
+    fn per_network_sections_parse() {
+        let toml_str = r#"
+default-network = "esmeralda"
+
+[networks.esmeralda]
+wallet-daemon-url = "http://localhost:5100/json_rpc"
+template-address = "template_0000000000000000000000000000000000000000000000000000000000000000"
+
+[networks.localnet]
+wallet-daemon-url = "http://localhost:9999/json_rpc"
+"#;
+        let cfg: ProjectConfig = toml::from_str(toml_str).expect("parse");
+        assert_eq!(cfg.default_network(), Some(Network::Esmeralda));
+        assert_eq!(
+            cfg.wallet_daemon_url(Network::Esmeralda).map(|u| u.as_str()),
+            Some("http://localhost:5100/json_rpc")
+        );
+        assert_eq!(
+            cfg.wallet_daemon_url(Network::LocalNet).map(|u| u.as_str()),
+            Some("http://localhost:9999/json_rpc")
+        );
+        assert!(cfg.template_address(Network::Esmeralda).is_some());
+        assert!(cfg.template_address(Network::LocalNet).is_none());
     }
 }

--- a/crates/cli/src/project/config.rs
+++ b/crates/cli/src/project/config.rs
@@ -57,8 +57,7 @@ impl ProjectConfig {
 
 impl Default for ProjectConfig {
     fn default() -> Self {
-        let wallet_url =
-            || Some(Url::parse(DEFAULT_WALLET_DAEMON_URL).expect("default wallet daemon URL is valid"));
+        let wallet_url = || Some(Url::parse(DEFAULT_WALLET_DAEMON_URL).expect("default wallet daemon URL is valid"));
         let metadata_url = |s: &str| Some(Url::parse(s).expect("default metadata server URL is valid"));
         let mut networks = HashMap::new();
         networks.insert(

--- a/crates/cli/src/project/config.rs
+++ b/crates/cli/src/project/config.rs
@@ -55,11 +55,21 @@ impl ProjectConfig {
 
 impl Default for ProjectConfig {
     fn default() -> Self {
+        let default_url =
+            || Some(Url::parse(DEFAULT_WALLET_DAEMON_URL).expect("default wallet daemon URL is valid"));
         let mut networks = HashMap::new();
         networks.insert(
             Network::Esmeralda,
             ProjectNetworkSettings {
-                wallet_daemon_url: Some(Url::parse(DEFAULT_WALLET_DAEMON_URL).expect("default URL is valid")),
+                wallet_daemon_url: default_url(),
+                metadata_server_url: None,
+                template_address: None,
+            },
+        );
+        networks.insert(
+            Network::LocalNet,
+            ProjectNetworkSettings {
+                wallet_daemon_url: default_url(),
                 metadata_server_url: None,
                 template_address: None,
             },

--- a/crates/cli/src/project/config.rs
+++ b/crates/cli/src/project/config.rs
@@ -10,6 +10,8 @@ use tari_ootle_publish_lib::walletd_client::ComponentAddressOrName;
 use url::Url;
 
 pub const DEFAULT_WALLET_DAEMON_URL: &str = "http://127.0.0.1:5100/json_rpc";
+pub const DEFAULT_METADATA_SERVER_URL_ESMERALDA: &str = "https://ootle-templates-esme.tari.com/";
+pub const DEFAULT_METADATA_SERVER_URL_LOCALNET: &str = "http://localhost:3000";
 
 /// Project configuration.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -55,22 +57,23 @@ impl ProjectConfig {
 
 impl Default for ProjectConfig {
     fn default() -> Self {
-        let default_url =
+        let wallet_url =
             || Some(Url::parse(DEFAULT_WALLET_DAEMON_URL).expect("default wallet daemon URL is valid"));
+        let metadata_url = |s: &str| Some(Url::parse(s).expect("default metadata server URL is valid"));
         let mut networks = HashMap::new();
         networks.insert(
             Network::Esmeralda,
             ProjectNetworkSettings {
-                wallet_daemon_url: default_url(),
-                metadata_server_url: None,
+                wallet_daemon_url: wallet_url(),
+                metadata_server_url: metadata_url(DEFAULT_METADATA_SERVER_URL_ESMERALDA),
                 template_address: None,
             },
         );
         networks.insert(
             Network::LocalNet,
             ProjectNetworkSettings {
-                wallet_daemon_url: default_url(),
-                metadata_server_url: None,
+                wallet_daemon_url: wallet_url(),
+                metadata_server_url: metadata_url(DEFAULT_METADATA_SERVER_URL_LOCALNET),
                 template_address: None,
             },
         );

--- a/crates/publish_lib/Cargo.toml
+++ b/crates/publish_lib/Cargo.toml
@@ -14,8 +14,8 @@ tari_engine = { workspace = true }
 tari_engine_types = { workspace = true }
 tari_template_lib_types = { workspace = true }
 tari_ootle_template_metadata = { workspace = true }
-tari_ootle_wallet_sdk = "0.28.9"
-ootle_serde = { version = "0.2", features = ["hex"] }
+tari_ootle_wallet_sdk = { workspace = true }
+ootle_serde = { workspace = true, features = ["hex"] }
 
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 serde = { workspace = true }

--- a/docs/01-getting-started/workflow.md
+++ b/docs/01-getting-started/workflow.md
@@ -135,8 +135,10 @@ cd templates/staking_pool/src
 ```bash
 # Configure for development network
 cat > tari.config.toml << EOF
-[network]
-wallet-daemon-jrpc-address = "http://127.0.0.1:9000/"
+default-network = "localnet"
+
+[networks.localnet]
+wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
 EOF
 
 # Set up testing environment
@@ -214,8 +216,10 @@ tari new ProductionToken --template audited-token-v2
 
 # Security configuration
 cat > tari.config.toml << EOF
-[network]
-wallet-daemon-jrpc-address = "https://secure-mainnet-wallet:9000/"
+default-network = "mainnet"
+
+[networks.mainnet]
+wallet-daemon-url = "https://secure-mainnet-wallet:9000/json_rpc"
 EOF
 ```
 
@@ -240,8 +244,10 @@ find . -name "*.rs" -exec grep -l "TODO\|FIXME\|XXX" {} \;
 ```bash
 # Deploy to testnet first
 cat > tari.config.testnet.toml << EOF
-[network]
-wallet-daemon-jrpc-address = "https://testnet-wallet:9000/"
+default-network = "esmeralda"
+
+[networks.esmeralda]
+wallet-daemon-url = "https://testnet-wallet:9000/json_rpc"
 EOF
 
 # Testnet deployment
@@ -414,8 +420,9 @@ jobs:
       - name: Test Template Deployment (Dry Run)
         run: |
           # Configure for CI environment
-          echo '[network]' > tari.config.toml
-          echo 'wallet-daemon-jrpc-address = "http://ci-wallet:9000/"' >> tari.config.toml
+          echo 'default-network = "localnet"' > tari.config.toml
+          echo '[networks.localnet]' >> tari.config.toml
+          echo 'wallet-daemon-url = "http://ci-wallet:5100/json_rpc"' >> tari.config.toml
           
           # Test deployment process (without actual deployment)
           # tari deploy --account ci-test --dry-run template-name

--- a/docs/02-guides/deployment.md
+++ b/docs/02-guides/deployment.md
@@ -85,8 +85,10 @@ Default configuration publishes to local development network:
 
 ```toml
 # In tari.config.toml
-[network]
-wallet-daemon-jrpc-address = "http://127.0.0.1:9000/"
+default-network = "localnet"
+
+[networks.localnet]
+wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
 ```
 
 Local publishing is ideal for:
@@ -277,8 +279,10 @@ tari_wallet_daemon --network localnet
 **Configuration**:
 ```toml
 # Custom testnet configuration
-[network]
-wallet-daemon-jrpc-address = "http://testnet-node:9000/"
+default-network = "esmeralda"
+
+[networks.esmeralda]
+wallet-daemon-url = "http://testnet-node:5100/json_rpc"
 ```
 
 ### Mainnet Publishing

--- a/docs/02-guides/project-configuration.md
+++ b/docs/02-guides/project-configuration.md
@@ -16,20 +16,32 @@ Every Tari project requires a `tari.config.toml` file in the project root for de
 
 ### Network Configuration
 
-<!-- SOURCE: crates/cli/src/project/config.rs:27-32 -->
-<!-- VERIFIED: 2025-06-26 -->
+<!-- SOURCE: crates/cli/src/project/config.rs -->
+<!-- VERIFIED: 2026-04-22 -->
 
 ```toml
-[network]
-wallet-daemon-jrpc-address = "http://127.0.0.1:9000/"
+default-network = "esmeralda"
+
+[networks.esmeralda]
+wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
+metadata-server-url = "https://ootle-templates-esme.tari.com/"
+
+[networks.localnet]
+wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
+metadata-server-url = "http://localhost:3000/"
 ```
 
-**Required Fields:**
+**Top-level fields:**
 
-- `wallet-daemon-jrpc-address` (string): JSON-RPC URL of the running Tari Wallet Daemon
-    - **Default**: `http://127.0.0.1:9000/`
-    - **Format**: Full HTTP/HTTPS URL with port
-    - **Example**: `http://127.0.0.1:9000/` for local development
+- `default-network` (string): One of `mainnet`, `stagenet`, `nextnet`, `localnet`, `igor`, `esmeralda`. Selected when no `--network` flag is given. Default: `esmeralda`.
+
+**Per-network `[networks.<name>]` fields:**
+
+- `wallet-daemon-url` (string): JSON-RPC URL of the Tari Wallet Daemon for this network. Default: `http://127.0.0.1:5100/json_rpc`.
+- `metadata-server-url` (string, optional): Metadata server for this network.
+- `template-address` (string, optional): Most recently published template address — written automatically by `tari publish`.
+
+Override the active network on any command with `-n <name>` / `--network <name>`.
 
 ### CLI Configuration
 
@@ -163,7 +175,7 @@ Options:
 
 1. **Tari Wallet Daemon**: Must be running and accessible
     - Download from: https://github.com/tari-project/tari-dan
-    - Default address: `http://127.0.0.1:9000/`
+    - Default address: `http://127.0.0.1:5100/json_rpc`
     - Requires authentication with Admin permissions
 
 2. **Rust Toolchain**: Required for template compilation
@@ -180,23 +192,31 @@ Options:
 ### Local Development
 
 ```toml
-[network]
-wallet-daemon-jrpc-address = "http://127.0.0.1:9000/"
+default-network = "localnet"
+
+[networks.localnet]
+wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
+metadata-server-url = "http://localhost:3000/"
 ```
 
-### Custom Networks
+### Switching Networks
 
-For custom Tari networks, ensure the wallet daemon is configured for the target network:
+Per-network sections let a single project target multiple networks:
 
 ```toml
-[network]
-wallet-daemon-jrpc-address = "http://custom-network-host:9000/"
+default-network = "esmeralda"
+
+[networks.esmeralda]
+wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
+
+[networks.localnet]
+wallet-daemon-url = "http://127.0.0.1:5101/json_rpc"
 ```
 
-Use the `--custom-network` flag when deploying:
+Switch networks per-command with `--network`:
 
 ```bash
-tari deploy --account myaccount --custom-network testnet my_template
+tari --network localnet publish -a myaccount
 ```
 
 ## Template Development
@@ -224,7 +244,7 @@ The CLI automatically handles this compilation during deployment.
 ### Common Configuration Issues
 
 1. **Wallet Daemon Connection Failed**
-    - Verify `wallet-daemon-jrpc-address` in `tari.config.toml`
+    - Verify `[networks.<active>].wallet-daemon-url` in `tari.config.toml`
     - Ensure wallet daemon is running and accessible
     - Check network firewall settings
 

--- a/docs/02-guides/real-world-examples.md
+++ b/docs/02-guides/real-world-examples.md
@@ -62,8 +62,10 @@ cd nft-marketplace-platform
 
 # Configure for testnet deployment
 cat > tari.config.toml << EOF
-[network]
-wallet-daemon-jrpc-address = "https://testnet-wallet.tari.com:9000/"
+default-network = "esmeralda"
+
+[networks.esmeralda]
+wallet-daemon-url = "https://testnet-wallet.tari.com:9000/json_rpc"
 EOF
 ```
 

--- a/docs/02-guides/template-development.md
+++ b/docs/02-guides/template-development.md
@@ -59,8 +59,10 @@ wasm_templates = "true"
 Include a default `tari.config.toml`:
 
 ```toml
-[network]
-wallet-daemon-jrpc-address = "http://127.0.0.1:9000/"
+default-network = "esmeralda"
+
+[networks.esmeralda]
+wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
 ```
 
 ### Cargo Workspace Configuration

--- a/docs/03-reference/cli-commands.md
+++ b/docs/03-reference/cli-commands.md
@@ -1,8 +1,8 @@
 ---
 title: CLI Commands Reference
 description: Complete reference for all Tari CLI commands, arguments, and options
-last_updated: 2026-04-14
-version: "0.14"
+last_updated: 2026-04-22
+version: "0.15"
 verified_against: crates/cli/src/cli/command.rs, command implementations
 audience: users
 ---
@@ -23,7 +23,8 @@ tari [GLOBAL_OPTIONS] <COMMAND> [COMMAND_OPTIONS]
 |--------|-------|-------------|---------|
 | `--base-dir <PATH>` | `-b` | Base directory for CLI data | `~/.local/share/tari_cli` |
 | `--config-file-path <PATH>` | `-c` | Config file location | `~/.config/tari_cli/tari.config.toml` |
-| `--config-overrides <KEY=VALUE>` | `-e` | Config file overrides | None |
+| `--config-overrides <KEY=VALUE>` | `-e` | Config file overrides (e.g. `networks.esmeralda.wallet-daemon-url=...`) | None |
+| `--network <NETWORK>` | `-n` | Active network (`esmeralda`, `localnet`, `igor`, `nextnet`, `stagenet`, `mainnet`). Overrides project and global `default-network` | Project / global default |
 
 ## Commands Overview
 
@@ -134,27 +135,33 @@ tari publish [OPTIONS] [PATH]
 |-------------------|------|---------|-------------|
 | `[PATH]` | Path | `.` | Path to the template crate directory |
 | `-a, --account` | String | Config or wallet default | Account for publishing fees |
+| `-n, --network` | Network | Project/global default | Active network (overrides config) |
 | `-c, --custom-network` | String | Config default | Custom network name |
 | `-y, --yes` | Flag | `false` | Skip confirmation prompt |
 | `-f, --max-fee` | u64 | Auto-estimated | Maximum fee in microtari |
 | `--binary, --bin` | Path | *builds if not set* | Path to pre-compiled WASM binary |
-| `--wallet-daemon-url` | URL | Config default | Wallet daemon JSON-RPC URL |
+| `--wallet-daemon-url` | URL | `[networks.<active>].wallet-daemon-url` | Wallet daemon JSON-RPC URL |
 | `--publish-metadata` | Flag | `false` | Auto-submit metadata to server after publishing |
-| `--metadata-server-url` | URL | Config or `localhost:3000` | Metadata server URL (with `--publish-metadata`) |
+| `--metadata-server-url` | URL | `[networks.<active>].metadata-server-url` | Metadata server URL (with `--publish-metadata`) |
+
+Before publishing, the CLI verifies the wallet daemon is on the same network as the active CLI network and aborts with an error if they differ.
 
 After publishing:
-- The template address is saved to `tari.config.toml` (so `tari metadata publish` can omit `--template-address`)
+- The template address is saved under `[networks.<active>].template-address` in `tari.config.toml` (so `tari metadata publish` can omit `--template-address`)
 - If metadata is detected and `--publish-metadata` is not set, you will be prompted to publish it
-- If a template address already exists in config (republishing), a warning is shown
+- If a template address already exists for the active network (republishing), a warning is shown
 
 ### Example
 
 ```bash
-# Build and publish
+# Build and publish (uses default-network from config)
 tari publish -a myaccount -y
 
 # Publish and auto-submit metadata
 tari publish -a myaccount --publish-metadata
+
+# Override the active network
+tari --network localnet publish -a myaccount
 ```
 
 ---
@@ -225,12 +232,13 @@ tari metadata publish [OPTIONS] [-t <TEMPLATE_ADDRESS>]
 | Argument / Option | Type | Default | Description |
 |-------------------|------|---------|-------------|
 | `[PATH]` | Path | `.` | Path to template crate directory |
-| `-t, --template-address` | Address | From config | Template address. If omitted, uses the address saved by `tari publish` |
-| `--metadata-server-url` | URL | Config or `localhost:3000` | Metadata server URL |
+| `-n, --network` | Network | Project/global default | Active network (overrides config) |
+| `-t, --template-address` | Address | `[networks.<active>].template-address` | Template address. If omitted, uses the address saved by `tari publish` |
+| `--metadata-server-url` | URL | `[networks.<active>].metadata-server-url` | Metadata server URL |
 | `--max-retries` | u32 | `6` | Max retry attempts for 404 (template not yet synced) |
 | `--signed` | Flag | `false` | Use author-signed submission via wallet daemon |
 | `--key-index` | u64 | `0` | Derived account key index (with `--signed`) |
-| `--wallet-daemon-url` | URL | Config default | Wallet daemon URL (with `--signed`) |
+| `--wallet-daemon-url` | URL | `[networks.<active>].wallet-daemon-url` | Wallet daemon URL (with `--signed`) |
 
 #### Hash-verified (default)
 
@@ -274,9 +282,10 @@ tari config set <KEY> <VALUE>
 
 Examples:
 ```bash
-tari config set network.wallet-daemon-jrpc-address http://localhost:12008/json_rpc
-tari config set metadata_server_url http://community.example.com
-tari config set default_account myaccount
+tari config set networks.localnet.wallet-daemon-url http://localhost:12008/json_rpc
+tari config set networks.esmeralda.metadata-server-url http://community.example.com
+tari config set default-network localnet
+tari config set default-account myaccount
 ```
 
 ### `config get`
@@ -307,13 +316,18 @@ Running `tari` with no command launches an interactive setup wizard that walks y
 
 ## Configuration Resolution
 
-Settings are resolved in priority order (highest first):
+The active network is resolved first, then per-setting values are read from that network's section.
+
+**Active network** (highest priority first): `--network` → project `default-network` → global `default-network` → `esmeralda`.
+
+**Per-setting** (highest priority first):
 
 | Setting | CLI flag | Project config | Global config | Default |
 |---------|----------|---------------|---------------|---------|
-| Wallet daemon URL | `--wallet-daemon-url` | `network.wallet-daemon-jrpc-address` | `wallet_daemon_url` | `http://127.0.0.1:9000/json_rpc` |
-| Metadata server URL | `--metadata-server-url` | `metadata-server-url` | `metadata_server_url` | `http://localhost:3000` |
-| Account | `--account` | `default_account` | `default_account` | Wallet daemon default |
+| Wallet daemon URL | `--wallet-daemon-url` | `networks.<active>.wallet-daemon-url` | `networks.<active>.wallet-daemon-url` | `http://127.0.0.1:5100/json_rpc` |
+| Metadata server URL | `--metadata-server-url` | `networks.<active>.metadata-server-url` | `networks.<active>.metadata-server-url` | esmeralda → `https://ootle-templates-esme.tari.com/`, localnet → `http://localhost:3000/`, others → none |
+| Template address | `--template-address` | `networks.<active>.template-address` | — | — |
+| Account | `--account` | `default-account` | `default-account` | Wallet daemon default |
 
 ---
 

--- a/docs/03-reference/configuration-schema.md
+++ b/docs/03-reference/configuration-schema.md
@@ -1,8 +1,8 @@
 ---
 title: Configuration Schema Reference
 description: Complete reference for all Tari CLI configuration options and file formats
-last_updated: 2026-04-14
-version: "0.14"
+last_updated: 2026-04-22
+version: "0.15"
 verified_against: crates/cli/src/cli/config.rs, crates/cli/src/project/config.rs
 audience: users
 ---
@@ -13,12 +13,21 @@ audience: users
 
 ## Configuration Hierarchy
 
-Settings are resolved in this order (highest priority first):
+Both the global CLI config and the project config are organised by **network** (`esmeralda`, `localnet`, `igor`, `nextnet`, `stagenet`, `mainnet`). Each command resolves an **active network** and then reads `wallet-daemon-url`, `metadata-server-url`, and `template-address` from the matching `[networks.<name>]` section.
+
+### Active network resolution (highest priority first)
+
+1. `--network <name>` (`-n`) on the command line
+2. `default-network` in the project `tari.config.toml`
+3. `default-network` in the global CLI config
+4. `esmeralda` (built-in default)
+
+### Per-setting resolution (highest priority first)
 
 1. **Command-line flags** (`--wallet-daemon-url`, `--metadata-server-url`, etc.)
 2. **CLI overrides** (`-e KEY=VALUE`)
-3. **Project configuration** (`tari.config.toml` in project or git root)
-4. **Global CLI configuration** (`~/.config/tari_cli/tari.config.toml`)
+3. **Project configuration** — `[networks.<active>]` in `tari.config.toml`
+4. **Global CLI configuration** — `[networks.<active>]` in `~/.config/tari_cli/tari.config.toml`
 5. **Built-in defaults**
 
 ---
@@ -36,18 +45,31 @@ Settings are resolved in this order (highest priority first):
 ```toml
 # ~/.config/tari_cli/tari.config.toml
 
+default-network = "esmeralda"
+# default-account = "myaccount"
+
 [template-repository]
 url = "https://github.com/tari-project/wasm-template"
 branch = "main"
 folder = "wasm_templates"
 
-# Optional
-# wallet-daemon-url = "http://127.0.0.1:9000/json_rpc"
-# metadata-server-url = "http://localhost:3000"
-# default-account = "myaccount"
+[networks.esmeralda]
+wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
+metadata-server-url = "https://ootle-templates-esme.tari.com/"
+
+[networks.localnet]
+wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
+metadata-server-url = "http://localhost:3000/"
 ```
 
 ### Fields
+
+#### Top-level
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `default-network` | Network | `esmeralda` | Used when no `--network` flag and no project default-network |
+| `default-account` | String | None | Default wallet account for publishing |
 
 #### `[template-repository]`
 
@@ -57,13 +79,12 @@ folder = "wasm_templates"
 | `branch` | String | `main` | Git branch |
 | `folder` | String | `wasm_templates` | Subdirectory containing templates |
 
-#### Top-level optional fields
+#### `[networks.<name>]`
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `wallet-daemon-url` | URL | None | Global wallet daemon JSON-RPC URL |
-| `metadata-server-url` | URL | None | Global metadata server URL |
-| `default-account` | String | None | Default wallet account for publishing |
+| `wallet-daemon-url` | URL | `http://127.0.0.1:5100/json_rpc` | Wallet daemon JSON-RPC endpoint |
+| `metadata-server-url` | URL | esmeralda → `https://ootle-templates-esme.tari.com/`, localnet → `http://localhost:3000/`, others → none | Metadata server URL |
 
 ### CLI Overrides (`-e`)
 
@@ -75,11 +96,12 @@ Valid override keys:
 | `template_repository.branch` | `development` |
 | `template_repository.folder` | `my_templates` |
 | `default_account` | `myaccount` |
-| `wallet_daemon_url` | `http://localhost:12008/json_rpc` |
-| `metadata_server_url` | `http://community.example.com` |
+| `default_network` | `localnet` |
+| `networks.<name>.wallet-daemon-url` | `http://localhost:12008/json_rpc` |
+| `networks.<name>.metadata-server-url` | `http://community.example.com` |
 
 ```bash
-tari -e "wallet_daemon_url=http://localhost:12008/json_rpc" publish
+tari -e "networks.esmeralda.wallet-daemon-url=http://localhost:12008/json_rpc" publish
 ```
 
 ---
@@ -95,42 +117,52 @@ tari -e "wallet_daemon_url=http://localhost:12008/json_rpc" publish
 ```toml
 # tari.config.toml
 
-[network]
-wallet-daemon-jrpc-address = "http://127.0.0.1:5100/json_rpc"
-
-# Optional
+default-network = "esmeralda"
 # default-account = "myaccount"
-# metadata-server-url = "http://localhost:3000"
-# template-address = "template_abc123..."
+
+[networks.esmeralda]
+wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
+metadata-server-url = "https://ootle-templates-esme.tari.com/"
+# template-address = "template_abc123..."  # written automatically by `tari publish`
+
+[networks.localnet]
+wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
+metadata-server-url = "http://localhost:3000/"
 ```
 
 ### Fields
 
-#### `[network]`
+#### Top-level
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `wallet-daemon-jrpc-address` | URL | `http://127.0.0.1:5100/json_rpc` | Wallet daemon JSON-RPC endpoint |
-
-#### Top-level optional fields
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
+| `default-network` | Network | `esmeralda` | Active network when no `--network` flag is set |
 | `default-account` | String | None | Default wallet account |
-| `metadata-server-url` | URL | None | Metadata server URL |
-| `template-address` | Address | None | Template address (saved automatically by `tari publish`) |
+
+#### `[networks.<name>]`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `wallet-daemon-url` | URL | `http://127.0.0.1:5100/json_rpc` | Wallet daemon JSON-RPC endpoint |
+| `metadata-server-url` | URL | None | Metadata server URL for this network |
+| `template-address` | Address | None | Most recently published template address (written automatically by `tari publish`) |
+
+`<name>` is a value of the `Network` enum: `mainnet`, `stagenet`, `nextnet`, `localnet`, `igor`, `esmeralda`.
 
 ### Managing Project Configuration
 
 ```bash
-# Create default config
+# Create default config (esmeralda + localnet sections)
 tari config init
 
-# Set wallet daemon URL
-tari config set network.wallet-daemon-jrpc-address http://localhost:12008/json_rpc
+# Set wallet daemon URL for a specific network
+tari config set networks.localnet.wallet-daemon-url http://localhost:12008/json_rpc
 
-# Set metadata server
-tari config set metadata_server_url http://community.example.com
+# Change the default network
+tari config set default-network localnet
+
+# Set metadata server for esmeralda
+tari config set networks.esmeralda.metadata-server-url http://community.example.com
 
 # View current config
 tari config show

--- a/docs/04-troubleshooting/common-issues.md
+++ b/docs/04-troubleshooting/common-issues.md
@@ -194,17 +194,19 @@ curl -X POST http://127.0.0.1:9000/ \
    ```
 
 2. **Verify Network Configuration**:
-   <!-- SOURCE: Verified against crates/cli/src/project/config.rs:30 -->
+   <!-- SOURCE: Verified against crates/cli/src/project/config.rs -->
    ```toml
    # In tari.config.toml
-   [network]
-   wallet-daemon-jrpc-address = "http://127.0.0.1:9000/"
+   default-network = "esmeralda"
+
+   [networks.esmeralda]
+   wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
    ```
 
 3. **Test Different Port**:
    ```bash
    # Check if port is available
-   netstat -an | grep 9000
+   netstat -an | grep 5100
    
    # Use alternative port if needed
    tari_wallet_daemon --json-rpc-address "127.0.0.1:9001"
@@ -390,8 +392,10 @@ Connection refused to network endpoint
 1. **Verify Network Configuration**:
    ```toml
    # Check tari.config.toml
-   [network]
-   wallet-daemon-jrpc-address = "http://127.0.0.1:9000/"
+   default-network = "esmeralda"
+
+   [networks.esmeralda]
+   wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
    ```
 
 2. **Test Network Connection**:

--- a/docs/04-troubleshooting/faq.md
+++ b/docs/04-troubleshooting/faq.md
@@ -199,17 +199,22 @@ serde = { version = "1.0", features = ["derive"] }
 
 ### Q: How do I deploy to different networks?
 
-**A**: Configure the network in your project's `tari.config.toml`:
+**A**: Define a section per network in your project's `tari.config.toml` and select one with `default-network` (or override per-command with `--network`):
 
 ```toml
-[network]
-wallet-daemon-jrpc-address = "http://127.0.0.1:9000/"  # Local
-# wallet-daemon-jrpc-address = "https://testnet:9000/"  # Testnet
+default-network = "esmeralda"
+
+[networks.localnet]
+wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
+
+[networks.esmeralda]
+wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
 ```
 
 Then deploy:
 ```bash
-tari deploy --account myaccount my-contract
+tari deploy --account myaccount                          # uses default-network
+tari --network localnet deploy --account myaccount       # override
 ```
 
 ### Q: What happens after successful deployment?
@@ -373,18 +378,27 @@ done
 
 ### Q: How do I switch between networks?
 
-**A**: Update your project's `tari.config.toml`:
+**A**: Either change `default-network` in `tari.config.toml`, or pass `--network <name>` per command. Each network keeps its own wallet daemon URL, metadata server URL, and published template address:
 
 ```toml
-[network]
-# Development
-wallet-daemon-jrpc-address = "http://127.0.0.1:9000/"
+default-network = "esmeralda"
 
-# Testnet  
-# wallet-daemon-jrpc-address = "https://testnet-wallet:9000/"
+[networks.esmeralda]
+wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
 
-# Custom
-# wallet-daemon-jrpc-address = "https://my-network:9000/"
+[networks.localnet]
+wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
+
+[networks.mainnet]
+wallet-daemon-url = "https://my-mainnet-wallet:5100/json_rpc"
+```
+
+```bash
+# Use default-network
+tari publish
+
+# Override for one command
+tari --network localnet publish
 ```
 
 ### Q: Can I deploy the same contract to multiple networks?


### PR DESCRIPTION
## Summary

- Nest `wallet-daemon-url`, `metadata-server-url`, and `template-address` under `[networks.<name>]` sections in both project (`tari.config.toml`) and global CLI config, keyed by the `Network` enum from `tari_ootle_common_types`.
- Add a `default-network` setting (defaults to `esmeralda`) and a global `-n/--network <NETWORK>` flag that overrides it on any command.
- Active network resolution: `--network` flag → project `default-network` → global `default-network` → `Esmeralda`. Wallet daemon URL, metadata server URL, and template address all look up the resolved network's section, with per-command URL flags still winning.
- Default wallet daemon URL for esmeralda is `http://127.0.0.1:5100/json_rpc` (unchanged from the previous flat default).
- `tari config set` generalised to arbitrary dotted-key depth so `networks.<net>.wallet-daemon-url` works.

Default project config now emits:

```toml
default-network = "esmeralda"
                                                                                                                                                                                                                                                                                                                                    
  [networks.esmeralda]                                                                                                                                                                                                                                                                                                                          
  wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"                                                                                                                                                                                                                                                                                          
  metadata-server-url = "..."                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                
  [networks.localnet]
  wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"                                                                                                                                                                                                                                                                                          
  metadata-server-url = "http://localhost:3000/"                      
                                                    

```

No backwards-compat shim — existing flat `tari.config.toml` files will need `tari config init` or a manual edit.

## Test plan

- [x] `cargo test --workspace` passes (new roundtrip + per-network parse tests added).
- [x] `tari config init` emits the new layout (verified locally).
- [x] `tari config set networks.localnet.wallet-daemon-url …` / `tari config get …` round-trip through the deeper dotted-key setter.
- [x] `tari --network bogus publish` rejects invalid networks via clap.
- [x] `--network` shows up in both `tari --help` and `tari publish --help` (`global = true`).
- [x] Manual test: `tari publish` against a running esmeralda wallet daemon (not run in CI).
- [x] Manual test: `tari --network localnet publish` with a `[networks.localnet]` section in project config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)