### PR TITLE
chore: update deps to 0.30.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,25 +144,26 @@ dependencies = [
 
 [[package]]
 name = "argon2"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4ce4441f99dbd377ca8a8f57b698c44d0d6e712d8329b5040da5a64aa1ce73"
-dependencies = [
- "base64ct",
- "blake2",
- "password-hash 0.4.2",
-]
-
-[[package]]
-name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
- "blake2",
+ "blake2 0.10.6",
  "cpufeatures 0.2.17",
  "password-hash 0.5.0",
+]
+
+[[package]]
+name = "argon2"
+version = "0.6.0-rc.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af50940b73bf4e16c15c448a2b121c63f2d68e3e54b6a8731673cb4aa0cdff5"
+dependencies = [
+ "base64ct",
+ "blake2 0.11.0-rc.6",
+ "cpufeatures 0.3.0",
+ "password-hash 0.6.1",
 ]
 
 [[package]]
@@ -413,9 +414,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "base64urlsafedata"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f7f6be94fa637132933fd0a68b9140bcb60e3d46164cb68e82a2bb8d102b3a"
+checksum = "b08e33815c87d8cadcddb1e74ac307368a3751fbe40c961538afa21a1899f21c"
 dependencies = [
  "base64 0.21.7",
  "pastey 0.1.1",
@@ -491,6 +492,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "blake2"
+version = "0.11.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -906,6 +916,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "codespan-reporting"
@@ -1399,18 +1415,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
+name = "ctutils"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "fiat-crypto",
- "group",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "rustc_version",
+ "rustcrypto-group",
  "serde",
  "subtle",
  "zeroize",
@@ -1672,13 +1697,14 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
  "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -1909,20 +1935,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filetime"
@@ -2492,21 +2508,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3025,16 +3030,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3343,7 +3338,7 @@ dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -3587,18 +3582,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "merlin"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
-dependencies = [
- "byteorder",
- "keccak",
- "rand_core 0.6.4",
- "zeroize",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3752,9 +3735,9 @@ dependencies = [
 
 [[package]]
 name = "normpath"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf23ab2b905654b4cb177e30b629937b3868311d4e1cba859f899c041046e69b"
+checksum = "b9985ef7269fa99f3b12437bb698381da2428743ab90f20393f399fa14cab21a"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -3843,9 +3826,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ootle-network"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80eeb78332d89d07bcaf162a8ca0b588e7fdb0ed6cc8091325abc515456c34c8"
+checksum = "e3932a49c75b4d7099988c5df7e51028a0d003f817cb557b00becb81039450bf"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3853,9 +3836,9 @@ dependencies = [
 
 [[package]]
 name = "ootle_byte_type"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "752a5944471f02f6971359e2631af8f8eeb85acce3f7e5d74b60af43529220f9"
+checksum = "50fcc9c7b06bd31ce2e6f7b3fae3095b35bc1caa1ed3a7393238b1b8f7bb3c67"
 dependencies = [
  "tari_crypto",
  "tari_template_lib_types",
@@ -3881,15 +3864,14 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3919,9 +3901,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -3997,9 +3979,9 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
  "rand_core 0.6.4",
@@ -4008,13 +3990,12 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
 dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
+ "getrandom 0.4.2",
+ "phc",
 ]
 
 [[package]]
@@ -4106,19 +4087,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.11"
+name = "phc"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
+dependencies = [
+ "base64ct",
+ "ctutils",
+ "getrandom 0.4.2",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4510,6 +4502,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4579,9 +4581,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -4863,6 +4865,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustcrypto-ff"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
+name = "rustcrypto-group"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "369f9b61aa45933c062c9f6b5c3c50ab710687eca83dd3802653b140b43f85ed"
+dependencies = [
+ "rand_core 0.10.1",
+ "rustcrypto-ff",
+ "subtle",
 ]
 
 [[package]]
@@ -5254,7 +5277,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5600,7 +5623,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tari-ootle-cli"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "cargo-generate",
@@ -5643,30 +5666,31 @@ dependencies = [
 
 [[package]]
 name = "tari_bulletproofs_plus"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98e43bc4d522de252647e34e72aef4d5e33f845a6acc23fb7b1f4e877a7f9053"
+checksum = "4f2e5d22fc3d312561a24247689ac3ae180fb041e6ac11baf1317df3b1473ff8"
 dependencies = [
- "blake2",
+ "blake2 0.10.6",
  "byteorder",
  "curve25519-dalek",
  "digest 0.10.7",
- "ff",
+ "getrandom 0.4.2",
  "itertools 0.12.1",
- "merlin",
  "once_cell",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
+ "rustcrypto-ff",
  "serde",
  "sha3",
+ "tari_merlin",
  "thiserror-no-std",
  "zeroize",
 ]
 
 [[package]]
 name = "tari_common"
-version = "5.3.0-rc.0"
+version = "5.3.1-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e51cc5201ff066fd2a6bc5869a63be25c95f3bdfdf1f66e9a8e3fa6fd8c3dd"
+checksum = "516e329ec417f8fb86da0d7cfc7c42c6c5d9c8f357a1b45d1fe0c7a6e6a8378a"
 dependencies = [
  "anyhow",
  "cargo_toml 0.20.5",
@@ -5688,14 +5712,14 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "5.3.0-rc.0"
+version = "5.3.1-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b135f831c7efda9735ded24acacf9ac7c48a5349ee8c0480889d02cf7c80a3"
+checksum = "15dd3d500d2e59e380d75d6cc1a44b40248597694f910764c4ba67ea78beb59a"
 dependencies = [
- "argon2 0.4.1",
+ "argon2 0.6.0-rc.8",
  "base64 0.22.1",
  "bitflags 2.11.1",
- "blake2",
+ "blake2 0.10.6",
  "borsh",
  "bs58",
  "chacha20 0.7.3",
@@ -5703,11 +5727,12 @@ dependencies = [
  "crc32fast",
  "digest 0.10.7",
  "getrandom 0.2.17",
+ "getrandom 0.4.2",
  "js-sys",
  "newtype-ops",
  "once_cell",
  "primitive-types",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "strum 0.22.0",
@@ -5725,9 +5750,9 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.30.1"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584933cf625b98e9c88ab201ceb9395f80d8108711cedf146aa47401ac2c3606"
+checksum = "303dbeb837e2a43afb26bb7587756e8e240293666e5bec5dd257e5984d27eddc"
 dependencies = [
  "borsh",
  "ootle_serde",
@@ -5743,18 +5768,17 @@ dependencies = [
 
 [[package]]
 name = "tari_crypto"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74b1ee79be37e04fcdb307b2809e658f19e05f31a2b5263c128fc3a5e2dee16"
+checksum = "330e2160d7d72970e8fc5f7074cdad1b041e32e996bbb6799215c9ccd03d5310"
 dependencies = [
- "blake2",
+ "blake2 0.10.6",
  "borsh",
  "curve25519-dalek",
  "digest 0.10.7",
  "log",
- "merlin",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.1",
  "serde",
  "sha3",
  "snafu",
@@ -5766,15 +5790,15 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.30.1"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3ae1f94c2044790adbe147b878ff83c5667ee5423a81ec87d37cc1cbe64fec1"
+checksum = "471ab90f50c6131ddf14c6c4c7a66736ae47969ead3479a46c54a1d8e289fdc3"
 dependencies = [
- "blake2",
+ "blake2 0.10.6",
  "indexmap 2.14.0",
  "log",
  "ootle_byte_type",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "tari_bor",
  "tari_crypto",
@@ -5793,11 +5817,11 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.30.1"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f51f345856a6bd044c8f1fd99634d36a1e3086795165d401bfcf2ae38c660e"
+checksum = "3b4ec37a6078cd7f677500931c111f520e3ec342c29f053c30ee5151e5894c72"
 dependencies = [
- "blake2",
+ "blake2 0.10.6",
  "borsh",
  "bounded-vec",
  "digest 0.10.7",
@@ -5808,7 +5832,7 @@ dependencies = [
  "newtype-ops",
  "ootle_byte_type",
  "ootle_serde",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "tari_bor",
@@ -5822,17 +5846,17 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "5.3.0-rc.0"
+version = "5.3.1-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db5e95b5208bdadcefd534a8c790e02baaf42cd29da54d2a10e9d41a49d714f9"
+checksum = "9321b2a14632fa572d10bd05bccaecc4ca996d95d47e896c12c72fd52e5a4f26"
 
 [[package]]
 name = "tari_hashing"
-version = "5.3.0-rc.0"
+version = "5.3.1-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b99ff66f7fae442e1daf1dfacf96c09888bbe09eb8fc2268988ba1d049a66a69"
+checksum = "690fda9301fdee1215debf6ff05b777fc5ff81b3d3d11478c6961126d2029240"
 dependencies = [
- "blake2",
+ "blake2 0.10.6",
  "borsh",
  "digest 0.10.7",
  "tari_crypto",
@@ -5840,9 +5864,9 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.30.1"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7122f7cb99bfbe534d823f77c623050923923be76efd7784a498c5b7107035a4"
+checksum = "1ba51e87c955179506a0adf11cf4a66932f0dd3e049105f7b4d97d89a28b9625"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -5864,9 +5888,9 @@ dependencies = [
 
 [[package]]
 name = "tari_jellyfish"
-version = "5.3.0-rc.0"
+version = "5.3.1-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdaa1185310000df5298fc47111d5846c178a9cec3c94e624e1b7d94d06f7b3d"
+checksum = "db8b7d57e7b14cb80cac39c9b66d90e7cc4b44b4f455da974c4fb834646548aa"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -5879,9 +5903,9 @@ dependencies = [
 
 [[package]]
 name = "tari_max_size"
-version = "5.3.0-rc.0"
+version = "5.3.1-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7735c3c97a45952cb64ce5ee2688f34d57466ecd7feaa6a37fb6735f61ef1048"
+checksum = "5ce3e9925a69b4bd83001878decd10ace5b56367306d1eaaa4dbca45b6f58106"
 dependencies = [
  "borsh",
  "serde",
@@ -5890,10 +5914,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "tari_ootle_address"
-version = "0.4.3"
+name = "tari_merlin"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aea04b3a0491deb8423221b325b8fe861d074e43ccf3c94953a503f4ec6dc08"
+checksum = "1e3a83eb69bafaa639abc3573614acaa47abd1fc9fc35d12cab2df8e45352b83"
+dependencies = [
+ "byteorder",
+ "keccak",
+ "rand_core 0.10.1",
+ "zeroize",
+]
+
+[[package]]
+name = "tari_ootle_address"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5ec304d9a17858cc7c2c0773b3df3a1beb0d1887f898ae6f4388af28b58f91"
 dependencies = [
  "bech32",
  "ootle-network",
@@ -5906,11 +5942,11 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.30.1"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad7ab3edcd9ee90d6cef415f4fbb8276821f36df465791950702df1115c4260"
+checksum = "6441df17b67d86407e4b7c75a2d8f9360651c7e27bfd6cd3a1438bdcfb94cd1d"
 dependencies = [
- "blake2",
+ "blake2 0.10.6",
  "borsh",
  "bounded-vec",
  "digest 0.10.7",
@@ -5922,7 +5958,7 @@ dependencies = [
  "ootle_serde",
  "prost 0.14.3",
  "prost-types",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "tari_bor",
  "tari_crypto",
@@ -5935,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_publish_lib"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "hickory-proto",
  "ootle_serde",
@@ -5957,9 +5993,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_metadata"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad7f49ffe82406661e8ae57702bc6c28d5a6dc10448ed8e445a071d0cd1854c"
+checksum = "26d50bf2db305d20c1b299080d94a5c5a9eb92eca9c248f74e96d527b806819f"
 dependencies = [
  "borsh",
  "cargo_toml 0.22.3",
@@ -5977,9 +6013,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.30.1"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c0362708e86d885e1996b5feea10b7c1b9ac1c2273f233e18f320320078ef8b"
+checksum = "e953cabce9cfc8a137ccdbdd5cb583e05b2b63708ed683e8e2d316dcc3ee0c10"
 dependencies = [
  "borsh",
  "hex",
@@ -5988,7 +6024,7 @@ dependencies = [
  "ootle-network",
  "ootle_byte_type",
  "ootle_serde",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "tari_bor",
  "tari_crypto",
@@ -6002,12 +6038,12 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.30.1"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ddc71117f7e8ad8e5c455f49c144850b460057ee19ec7b4aa346ad6c6f6fdf"
+checksum = "d719cd55939a1b60cb5059108ff0e529c43d49e90de7138e4609fc45ac1fea6e"
 dependencies = [
  "argon2 0.5.3",
- "blake2",
+ "blake2 0.10.6",
  "borsh",
  "chacha20poly1305",
  "crc32fast",
@@ -6015,7 +6051,7 @@ dependencies = [
  "log",
  "ootle-network",
  "ootle_byte_type",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "subtle",
  "tari_crypto",
@@ -6030,12 +6066,11 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.30.1"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f454db8741ddd27b742195052ca3b7696bd688ef8001a67c4deb087605b409b6"
+checksum = "d7b8503ce1748bafc514d944d84b41992ab003d96f13da15060a422ad4c31d89"
 dependencies = [
  "anyhow",
- "digest 0.10.7",
  "futures",
  "keyring",
  "log",
@@ -6043,7 +6078,7 @@ dependencies = [
  "ootle_byte_type",
  "ootle_serde",
  "passwords",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "tari_bor",
  "tari_common_types",
@@ -6067,9 +6102,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb09e44cec8db0e939a932314f2004cfc2dffe2e43f77e3f5f6a6a7a534ea59"
+checksum = "67b341f7bb04afab71fa6173f735dcd66f5db4267419fc44b699b050ba1f9f16"
 dependencies = [
  "hex",
  "ootle_serde",
@@ -6093,9 +6128,9 @@ dependencies = [
 
 [[package]]
 name = "tari_sidechain"
-version = "5.3.0-rc.0"
+version = "5.3.1-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa2ecf36b51a3527ad7f7cff4812948d73595de494cee56dc15ad929d05f726"
+checksum = "428f77d3384b10c7cb6587f5e096ae4b62f61995016e5964d47cf587383d14d5"
 dependencies = [
  "borsh",
  "hex",
@@ -6111,9 +6146,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_abi"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bdb2b66b9db191152ec10f637657cd20f27151576f059fb215409ca09c10d93"
+checksum = "c9c1bb8738495f2662fc406aa8d39f4b0835518d7f83ef71e155bc5e14d06854"
 dependencies = [
  "serde",
  "tari_bor",
@@ -6122,9 +6157,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.30.1"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff28626fba1a5ae3572824f053bec09416a69d08a6ae69b4505c3e835a985b3"
+checksum = "ac1b7c2ac9ce850efc7ac5a1828810838447f602dc51c11c276b376e851fe7ef"
 dependencies = [
  "anyhow",
  "tari_template_lib_types",
@@ -6132,9 +6167,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc55e55d40841a262fc0270a34db9241d6d93809dbd06e8da51e29e572dfc6d4"
+checksum = "676f05986e7fb50c2fc5f257b87d5c2826ae801cb88c0ee4d3177339a0477087"
 dependencies = [
  "borsh",
  "serde",
@@ -6146,9 +6181,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib_types"
-version = "0.25.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fbe3f80db4ca6c62d449f850745a90082ade451e7d0b8b2fd17f76cde533a37"
+checksum = "e11b5b9907f6c68200b1b48c2622d9a7009a4f52ffba9364021c0a7fa34c981f"
 dependencies = [
  "bnum",
  "borsh",
@@ -6160,9 +6195,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4280c01eff9d0ba0e302a41c2f5b59c214bde5a8bc63a9b3881750ac6c1843d6"
+checksum = "1c0cd833e57f4a66846d11ec042c73eafa0da024ed77b401cc1a657f4aa578bc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6172,9 +6207,9 @@ dependencies = [
 
 [[package]]
 name = "tari_utilities"
-version = "0.8.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67c685a942b95a68c368603644223b7d5be5748bf8add16bd5042a7084e304d"
+checksum = "59020053bb363474087e5b170acbf0e1a848b1af5736e058a0332ce69b6dbf9e"
 dependencies = [
  "base58-monero",
  "base64 0.13.1",
@@ -6195,7 +6230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -6257,9 +6292,9 @@ dependencies = [
 
 [[package]]
 name = "thin-vec"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
 
 [[package]]
 name = "thiserror"
@@ -6397,9 +6432,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -6643,20 +6678,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -6868,9 +6903,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
 dependencies = [
  "indexmap 2.14.0",
  "serde",
@@ -6880,9 +6915,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7334,9 +7369,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-attestation-ca"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fafcf13f7dc1fb292ed4aea22cdd3757c285d7559e9748950ee390249da4da6b"
+checksum = "6475c0bbd1a3f04afaa3e98880408c5be61680c5e6bd3c6f8c250990d5d3e18e"
 dependencies = [
  "base64urlsafedata",
  "openssl",
@@ -7348,9 +7383,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-rs"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b24d082d3360258fefb6ffe56123beef7d6868c765c779f97b7a2fcf06727f8"
+checksum = "6c548915e0e92ee946bbf2aecf01ea21bef53d974b0793cc6732ba81a03fc422"
 dependencies = [
  "base64urlsafedata",
  "serde",
@@ -7362,9 +7397,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-rs-core"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15784340a24c170ce60567282fb956a0938742dbfbf9eff5df793a686a009b8b"
+checksum = "296d2d501feb715d80b8e186fb88bab1073bca17f460303a1013d17b673bea6a"
 dependencies = [
  "base64 0.21.7",
  "base64urlsafedata",
@@ -7389,9 +7424,9 @@ dependencies = [
 
 [[package]]
 name = "webauthn-rs-proto"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a1fb2580ce73baa42d3011a24de2ceab0d428de1879ece06e02e8c416e497c"
+checksum = "c37393beac9c1ed1ca6dbb30b1e01783fb316ab3a45d90ecd48c99052dd7ef1e"
 dependencies = [
  "base64 0.21.7",
  "base64urlsafedata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,21 +3,21 @@ members = ["crates/publish_lib", "crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.16.2"
+version = "0.17.0"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-cli"
 license = "BSD-3-Clause"
 
 [workspace.dependencies]
-tari_ootle_publish_lib = { path = "crates/publish_lib", version = "0.16" }
+tari_ootle_publish_lib = { path = "crates/publish_lib", version = "0.17" }
 
 tari_ootle_walletd_client = "0.30"
 tari_engine = "0.30"
 tari_engine_types = "0.30"
 tari_ootle_common_types = "0.30"
-tari_template_lib_types = "0.25"
-tari_ootle_template_metadata = "0.5"
+tari_template_lib_types = "0.26"
+tari_ootle_template_metadata = "0.6"
 tari_ootle_wallet_sdk = "0.30"
 ootle-network = "0.1"
 ootle_serde = "0.2"


### PR DESCRIPTION
## Summary
- Bump workspace deps to the newly published 0.30.4 stack (`tari_engine`, `tari_engine_types`, `tari_ootle_common_types`, `tari_ootle_wallet_sdk`, `tari_ootle_walletd_client`, etc.) — picked up via `cargo update` within existing version ranges.
- Bump `tari_template_lib_types` 0.25 → 0.26 and `tari_ootle_template_metadata` 0.5 → 0.6 in workspace specs so the dep graph deduplicates `tari_crypto`, `ootle_byte_type`, and friends.
- Bump workspace version 0.16.2 → 0.17.0.

No code changes were required.

## Test plan
- [x] `cargo check --workspace`
- [x] `cargo test --workspace` (15 passed)
- [x] `cargo clippy --workspace --all-targets` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)