### PR TITLE
fix: preserve base URL path prefix when publishing metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5623,7 +5623,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tari-ootle-cli"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "cargo-generate",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_publish_lib"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "hickory-proto",
  "ootle_serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/publish_lib", "crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.1"
+version = "0.17.2"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-cli"

--- a/crates/cli/src/cli/commands/metadata/publish.rs
+++ b/crates/cli/src/cli/commands/metadata/publish.rs
@@ -153,6 +153,23 @@ pub async fn handle(
     }
 }
 
+/// Build `<server_url>/api/templates/<addr>/metadata[/signed]`, preserving any
+/// path prefix on `server_url` (e.g. `/community-templates/`) regardless of
+/// whether it has a trailing slash.
+fn build_metadata_url(server_url: &Url, addr: &str, signed: bool) -> anyhow::Result<Url> {
+    let mut url = server_url.clone();
+    {
+        let mut segs = url
+            .path_segments_mut()
+            .map_err(|_| anyhow!("metadata server URL cannot be a base: {server_url}"))?;
+        segs.pop_if_empty().extend(["api", "templates", addr, "metadata"]);
+        if signed {
+            segs.push("signed");
+        }
+    }
+    Ok(url)
+}
+
 /// Flow 1: Hash-verified metadata publish (POST raw CBOR).
 pub async fn publish_metadata_to_server(
     server_url: &Url,
@@ -161,9 +178,7 @@ pub async fn publish_metadata_to_server(
     max_retries: u32,
 ) -> anyhow::Result<()> {
     let addr = template_address.as_template_address();
-    let url = server_url
-        .join(&format!("/api/templates/{addr}/metadata"))
-        .context("building metadata endpoint URL")?;
+    let url = build_metadata_url(server_url, &addr.to_string(), false).context("building metadata endpoint URL")?;
 
     let client = reqwest::Client::new();
     let mut backoff = Duration::from_secs(DEFAULT_INITIAL_BACKOFF_SECS);
@@ -211,9 +226,8 @@ pub async fn publish_metadata_signed(
     max_retries: u32,
 ) -> anyhow::Result<()> {
     let addr = template_address.as_template_address();
-    let url = server_url
-        .join(&format!("/api/templates/{addr}/metadata/signed"))
-        .context("building signed metadata endpoint URL")?;
+    let url =
+        build_metadata_url(server_url, &addr.to_string(), true).context("building signed metadata endpoint URL")?;
 
     let client = reqwest::Client::new();
     let mut backoff = Duration::from_secs(DEFAULT_INITIAL_BACKOFF_SECS);


### PR DESCRIPTION
## Summary
- `Url::join("/api/...")` treats a leading `/` as an absolute path and **replaces** the base path. With a metadata server URL like `https://ootle.tari.com/community-templates/`, the publish-metadata request collapsed to `https://ootle.tari.com/api/templates/<addr>/metadata` — the `/community-templates/` prefix was silently dropped, so the API never saw the request and the CLI just retried 404s until exhausting attempts.
- Build the endpoint with `path_segments_mut` instead, so any prefix on the configured server URL is preserved regardless of trailing slash. Applies to both the hash-verified and signed publish flows.
- Version bump to 0.17.2.

## Test plan
- [ ] `cargo build -p tari-ootle-cli` succeeds
- [ ] `tari publish-metadata` against a server URL with a path prefix (e.g. `https://ootle.tari.com/community-templates/`) hits `<prefix>/api/templates/<addr>/metadata` and the request shows up in API logs
- [ ] Same flow with `--signed` hits `<prefix>/api/templates/<addr>/metadata/signed`
- [ ] Server URL without a path prefix (e.g. `https://example.com/`) still resolves to `/api/templates/<addr>/metadata`
- [ ] Server URL without trailing slash (e.g. `https://example.com/community-templates`) is tolerated and still produces `/community-templates/api/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)