### PR TITLE
chore: bump workspace version to 0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5614,7 +5614,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tari-ootle-cli"
-version = "0.18.2"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "cargo-generate",
@@ -5966,7 +5966,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_publish_lib"
-version = "0.18.2"
+version = "0.19.0"
 dependencies = [
  "hickory-proto",
  "ootle_serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@ members = ["crates/publish_lib", "crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.18.2"
+version = "0.19.0"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-cli"
 license = "BSD-3-Clause"
 
 [workspace.dependencies]
-tari_ootle_publish_lib = { path = "crates/publish_lib", version = "0.18" }
+tari_ootle_publish_lib = { path = "crates/publish_lib", version = "0.19" }
 
 tari_ootle_walletd_client = "0.32"
 tari_engine = "0.32"


### PR DESCRIPTION
## Summary
- Bump workspace `version` to `0.19.0` (follows the 0.30→0.31 / 0.17→0.18 pattern from #139, applied to the 0.31→0.32 dep bump in #141)
- Bump `tari_ootle_publish_lib` workspace dep from `"0.18"` → `"0.19"` to match

Release prep for publishing `tari_ootle_publish_lib 0.19.0` and `tari-ootle-cli 0.19.0` to crates.io after #141.

## Test plan
- [x] cargo check --workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)