### PR TITLE
ci: publish crates to crates.io on release published

### DIFF
--- a/.github/scripts/publish-if-new.sh
+++ b/.github/scripts/publish-if-new.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Tari Project
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Publish a workspace crate to crates.io unless that exact name+version is
+# already published. Lets the workflow be re-run safely after a partial
+# failure (e.g. lib step succeeded, cli step failed).
+set -euo pipefail
+
+name=${1:?crate name required}
+version=$(cargo metadata --format-version 1 --no-deps \
+  | jq -r --arg name "$name" '.packages[] | select(.name == $name) | .version')
+
+if [ -z "$version" ] || [ "$version" = "null" ]; then
+  echo "error: could not resolve version for crate '$name'" >&2
+  exit 1
+fi
+
+status=$(curl -fsS -o /dev/null -w "%{http_code}" \
+  -H "User-Agent: github.com/tari-project/tari-cli publish workflow" \
+  "https://crates.io/api/v1/crates/$name/$version" || echo "000")
+
+case "$status" in
+  200)
+    echo "$name $version already on crates.io, skipping"
+    ;;
+  404)
+    echo "$name $version not yet published, publishing"
+    cargo publish --locked -p "$name"
+    ;;
+  *)
+    echo "error: unexpected HTTP $status checking crates.io for $name $version" >&2
+    exit 1
+    ;;
+esac

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -9,6 +9,8 @@ jobs:
   publish:
     name: Publish crates
     runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -26,11 +28,7 @@ jobs:
       # `cargo publish` waits for the new version to be queryable on the
       # registry before exiting, so the dependent publish below will resolve it.
       - name: Publish tari_ootle_publish_lib
-        run: cargo publish -p tari_ootle_publish_lib
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked -p tari_ootle_publish_lib
 
       - name: Publish tari-ootle-cli
-        run: cargo publish -p tari-ootle-cli
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked -p tari-ootle-cli

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -27,8 +27,13 @@ jobs:
       # Order matters: tari-ootle-cli depends on tari_ootle_publish_lib.
       # `cargo publish` waits for the new version to be queryable on the
       # registry before exiting, so the dependent publish below will resolve it.
+      #
+      # Each step checks crates.io first and skips if the workspace version is
+      # already published, so a re-run after a partial failure is safe.
       - name: Publish tari_ootle_publish_lib
-        run: cargo publish --locked -p tari_ootle_publish_lib
+        shell: bash
+        run: .github/scripts/publish-if-new.sh tari_ootle_publish_lib
 
       - name: Publish tari-ootle-cli
-        run: cargo publish --locked -p tari-ootle-cli
+        shell: bash
+        run: .github/scripts/publish-if-new.sh tari-ootle-cli

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,36 @@
+name: Publish to crates.io
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish crates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install system deps
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+
+      # Order matters: tari-ootle-cli depends on tari_ootle_publish_lib.
+      # `cargo publish` waits for the new version to be queryable on the
+      # registry before exiting, so the dependent publish below will resolve it.
+      - name: Publish tari_ootle_publish_lib
+        run: cargo publish -p tari_ootle_publish_lib
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish tari-ootle-cli
+        run: cargo publish -p tari-ootle-cli
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish-crates.yml`, triggered by `release: published` (and `workflow_dispatch` for manual reruns).
- Publishes the workspace crates in dependency order: `tari_ootle_publish_lib` first, then `tari-ootle-cli`.
- Authenticates with `secrets.CARGO_REGISTRY_TOKEN`.

## Prerequisite
- Add a `CARGO_REGISTRY_TOKEN` repository secret with a crates.io API token scoped to publish these crates. Without it the job will fail with an auth error on first run.

## Notes
- `cargo publish` (Cargo 1.66+) waits for the new version to be queryable on the index before exiting, so the second step can resolve the just-published lib.
- Reuses the same system deps (`libdbus-1-dev`, `pkg-config`) as the PR-check workflow so the build environment matches.

## Test plan
- [ ] Once merged and the `CARGO_REGISTRY_TOKEN` secret is set, trigger the workflow via `workflow_dispatch` against a pre-release tag (or wait for the next published release) and confirm both crates appear on crates.io.