### PR TITLE
feat: authenticate with wallet daemon via API key

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,14 +1,16 @@
 name: Publish to crates.io
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
 
 jobs:
   publish:
     name: Publish crates
     runs-on: ubuntu-latest
+    environment: cargopublish
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5606,7 +5606,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tari-ootle-cli"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "cargo-generate",
@@ -5626,6 +5626,7 @@ dependencies = [
  "tari_ootle_common_types",
  "tari_ootle_publish_lib",
  "tari_ootle_template_metadata",
+ "tari_utilities",
  "tempfile",
  "termimad",
  "thiserror 2.0.18",
@@ -5958,7 +5959,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_publish_lib"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "hickory-proto",
  "ootle_serde",
@@ -5970,6 +5971,7 @@ dependencies = [
  "tari_ootle_wallet_sdk",
  "tari_ootle_walletd_client",
  "tari_template_lib_types",
+ "tari_utilities",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@ members = ["crates/publish_lib", "crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-cli"
 license = "BSD-3-Clause"
 
 [workspace.dependencies]
-tari_ootle_publish_lib = { path = "crates/publish_lib", version = "0.19" }
+tari_ootle_publish_lib = { path = "crates/publish_lib", version = "0.20" }
 
 tari_ootle_walletd_client = "0.32"
 tari_engine = "0.32"
@@ -19,6 +19,7 @@ tari_ootle_common_types = "0.32"
 tari_template_lib_types = "0.27"
 tari_ootle_template_metadata = "0.7"
 tari_ootle_wallet_sdk = "0.32"
+tari_utilities = "0.10"
 ootle-network = "0.2"
 ootle_serde = "0.3"
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ export TARI_WALLET_DAEMON_API_KEY="<your-api-key>"
 tari publish -a myaccount
 ```
 
-The key must be minted with at least the `templates:read`, `templates:create` and `accounts:read` permissions. For security, it is never read from or written to a config file.
+The key must be minted with at least the `templates:read`, `templates:create`, `accounts:read` and `transactions:read` permissions (publishing waits on the transaction result to confirm). For security, it is never read from or written to a config file.
 
 See the [Configuration Schema Reference](https://tari-project.github.io/tari-cli/03-reference/configuration-schema/) for all options.
 
@@ -133,7 +133,7 @@ Full documentation is available at **[tari-project.github.io/tari-cli](https://t
 ## Prerequisites
 
 - [Tari Wallet Daemon](https://github.com/tari-project/tari-dan) running and accessible
-- A wallet daemon API key with `templates:read`, `templates:create` and `accounts:read` permissions (for publishing) — see [Wallet daemon authentication](#wallet-daemon-authentication)
+- A wallet daemon API key with `templates:read`, `templates:create`, `accounts:read` and `transactions:read` permissions (for publishing) — see [Wallet daemon authentication](#wallet-daemon-authentication)
 - Rust toolchain with `wasm32-unknown-unknown` target
 
 ## License

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ export TARI_WALLET_DAEMON_API_KEY="<your-api-key>"
 tari publish -a myaccount
 ```
 
-The key must be minted with at least the `template:read`, `template:write` and `account:read` permissions. For security, it is never read from or written to a config file.
+The key must be minted with at least the `templates:read`, `templates:create` and `accounts:read` permissions. For security, it is never read from or written to a config file.
 
 See the [Configuration Schema Reference](https://tari-project.github.io/tari-cli/03-reference/configuration-schema/) for all options.
 
@@ -133,7 +133,7 @@ Full documentation is available at **[tari-project.github.io/tari-cli](https://t
 ## Prerequisites
 
 - [Tari Wallet Daemon](https://github.com/tari-project/tari-dan) running and accessible
-- A wallet daemon API key with `template:read`, `template:write` and `account:read` permissions (for publishing) — see [Wallet daemon authentication](#wallet-daemon-authentication)
+- A wallet daemon API key with `templates:read`, `templates:create` and `accounts:read` permissions (for publishing) — see [Wallet daemon authentication](#wallet-daemon-authentication)
 - Rust toolchain with `wasm32-unknown-unknown` target
 
 ## License

--- a/README.md
+++ b/README.md
@@ -107,6 +107,19 @@ Pass `-n/--network <name>` to override the active network on any command (e.g. `
 
 Settings are resolved: **CLI flag > project config > global config > default**.
 
+### Wallet daemon authentication
+
+Commands that talk to the wallet daemon (`publish`, `template publish`, `metadata publish --signed`) authenticate with an **API key** issued by the wallet daemon. The key is sent as an `Authorization: Bearer` token — there is no interactive login.
+
+Provide it via the `--api-key` flag or the `TARI_WALLET_DAEMON_API_KEY` environment variable:
+
+```bash
+export TARI_WALLET_DAEMON_API_KEY="<your-api-key>"
+tari publish -a myaccount
+```
+
+The key must be minted with at least the `template:read`, `template:write` and `account:read` permissions. For security, it is never read from or written to a config file.
+
 See the [Configuration Schema Reference](https://tari-project.github.io/tari-cli/03-reference/configuration-schema/) for all options.
 
 ## Documentation
@@ -120,6 +133,7 @@ Full documentation is available at **[tari-project.github.io/tari-cli](https://t
 ## Prerequisites
 
 - [Tari Wallet Daemon](https://github.com/tari-project/tari-dan) running and accessible
+- A wallet daemon API key with `template:read`, `template:write` and `account:read` permissions (for publishing) — see [Wallet daemon authentication](#wallet-daemon-authentication)
 - Rust toolchain with `wasm32-unknown-unknown` target
 
 ## License

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,6 +17,7 @@ tari_ootle_template_metadata = { workspace = true, features = ["json"] }
 tari_ootle_common_types = { workspace = true }
 ootle-network = { workspace = true }
 tari_engine_types = { workspace = true }
+tari_utilities = { workspace = true }
 
 anyhow = "1.0.102"
 cargo-generate = "^0.23.7"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,7 +21,7 @@ tari_engine_types = { workspace = true }
 anyhow = "1.0.102"
 cargo-generate = "^0.23.7"
 cargo_toml = "0.22.3"
-clap = { version = "4.5.20", features = ["derive", "string"] }
+clap = { version = "4.5.20", features = ["derive", "string", "env"] }
 convert_case = "0.11.0"
 dialoguer = { version = "0.12.0", features = ["default", "fuzzy-select"] }
 dirs-next = "2.0.0"

--- a/crates/cli/src/cli/command.rs
+++ b/crates/cli/src/cli/command.rs
@@ -26,6 +26,7 @@ use clap::{
 use convert_case::{Case, Casing};
 use ootle_network::Network;
 use std::{convert::Infallible, env, path::PathBuf};
+use tari_ootle_publish_lib::PublisherError;
 use tari_utilities::Hidden;
 
 const DEFAULT_DATA_FOLDER_NAME: &str = "tari_cli";
@@ -106,6 +107,42 @@ mod tests {
         let ov = config_override_parser("default_account=acc=ount").expect("split_once should keep tail intact");
         assert_eq!(ov.value, "acc=ount");
     }
+
+    use anyhow::Context;
+    use tari_ootle_publish_lib::walletd_client::error::WalletDaemonClientError;
+
+    fn unauthorized_error() -> anyhow::Error {
+        // Mirror the real flow: a wallet daemon 401 wrapped in PublisherError, then
+        // given anyhow context by a handler.
+        let inner = PublisherError::WalletDaemonClient(WalletDaemonClientError::Unauthorized {
+            message: "token rejected".to_string(),
+        });
+        Err::<(), _>(inner).context("Failed to connect to the wallet").unwrap_err()
+    }
+
+    #[test]
+    fn appends_setup_help_on_unauthorized_without_key() {
+        let augmented = explain_wallet_daemon_auth_error(unauthorized_error(), false);
+        let msg = format!("{augmented:#}");
+        assert!(msg.contains("no API key was provided"), "got: {msg}");
+        assert!(msg.contains("TARI_WALLET_DAEMON_API_KEY"), "got: {msg}");
+    }
+
+    #[test]
+    fn appends_rejected_help_on_unauthorized_with_key() {
+        let augmented = explain_wallet_daemon_auth_error(unauthorized_error(), true);
+        let msg = format!("{augmented:#}");
+        assert!(msg.contains("rejected the provided API key"), "got: {msg}");
+    }
+
+    #[test]
+    fn leaves_non_auth_errors_untouched() {
+        let original = anyhow!("some unrelated failure");
+        let augmented = explain_wallet_daemon_auth_error(original, false);
+        let msg = format!("{augmented:#}");
+        assert_eq!(msg, "some unrelated failure");
+        assert!(!msg.contains("API key"));
+    }
 }
 
 pub fn project_name_parser(project_name: &str) -> Result<String, String> {
@@ -120,6 +157,43 @@ fn parse_network(s: &str) -> Result<Network, String> {
 /// [`Hidden`] so it is zeroized on drop and kept out of `Debug` output.
 fn parse_api_key(value: &str) -> Result<Hidden<String>, Infallible> {
     Ok(Hidden::hide(value.to_string()))
+}
+
+/// Guidance shown when the wallet daemon rejects a request because of
+/// authentication. The opening line is tailored to whether the user supplied a
+/// key at all, so a missing key and a bad key get distinct, actionable advice.
+fn wallet_daemon_auth_help(had_api_key: bool) -> String {
+    let intro = if had_api_key {
+        "The wallet daemon rejected the provided API key. It may be invalid, expired, \
+         or missing the required permissions."
+    } else {
+        "The wallet daemon requires authentication, but no API key was provided."
+    };
+    format!(
+        "🔑 {intro}\n\n\
+         Provide a key with the `--api-key` flag or the `TARI_WALLET_DAEMON_API_KEY` \
+         environment variable, for example:\n\n    \
+         export TARI_WALLET_DAEMON_API_KEY=\"<your-api-key>\"\n    \
+         tari publish -a <account>\n\n\
+         The key must be minted by the wallet daemon with at least the `templates:read`, \
+         `templates:create` and `accounts:read` permissions.\n\
+         See: https://tari-project.github.io/tari-cli/"
+    )
+}
+
+/// If `err` was caused by a wallet daemon authentication failure, append setup
+/// guidance so the user knows how to provide a valid API key. Any other error
+/// is returned unchanged.
+fn explain_wallet_daemon_auth_error(err: anyhow::Error, had_api_key: bool) -> anyhow::Error {
+    let unauthorized = err
+        .chain()
+        .any(|cause| cause.downcast_ref::<PublisherError>().is_some_and(PublisherError::is_unauthorized));
+
+    if unauthorized {
+        anyhow!("{err:#}\n\n{}", wallet_daemon_auth_help(had_api_key))
+    } else {
+        err
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -331,7 +405,8 @@ impl Cli {
                 let network_override = self.args.network;
                 // Move the key out rather than clone, so no extra plaintext copy lingers.
                 let api_key = self.args.api_key.take();
-                return match command {
+                let had_api_key = api_key.is_some();
+                let result = match command {
                     Command::Template { command } => match command {
                         TemplateCommand::Init { args } => template::init_metadata::handle(args).await,
                         TemplateCommand::Inspect { args } => template::inspect_metadata::handle(args).await,
@@ -348,6 +423,8 @@ impl Cli {
                     },
                     _ => unreachable!(),
                 };
+                // Surface API key setup help when the daemon rejects us for auth.
+                return result.map_err(|e| explain_wallet_daemon_auth_error(e, had_api_key));
             },
             _ => {},
         }

--- a/crates/cli/src/cli/command.rs
+++ b/crates/cli/src/cli/command.rs
@@ -117,7 +117,9 @@ mod tests {
         let inner = PublisherError::WalletDaemonClient(WalletDaemonClientError::Unauthorized {
             message: "token rejected".to_string(),
         });
-        Err::<(), _>(inner).context("Failed to connect to the wallet").unwrap_err()
+        Err::<(), _>(inner)
+            .context("Failed to connect to the wallet")
+            .unwrap_err()
     }
 
     #[test]
@@ -176,7 +178,7 @@ fn wallet_daemon_auth_help(had_api_key: bool) -> String {
          export TARI_WALLET_DAEMON_API_KEY=\"<your-api-key>\"\n    \
          tari publish -a <account>\n\n\
          The key must be minted by the wallet daemon with at least the `templates:read`, \
-         `templates:create` and `accounts:read` permissions.\n\
+         `templates:create`, `accounts:read` and `transactions:read` permissions.\n\
          See: https://tari-project.github.io/tari-cli/"
     )
 }
@@ -185,9 +187,11 @@ fn wallet_daemon_auth_help(had_api_key: bool) -> String {
 /// guidance so the user knows how to provide a valid API key. Any other error
 /// is returned unchanged.
 fn explain_wallet_daemon_auth_error(err: anyhow::Error, had_api_key: bool) -> anyhow::Error {
-    let unauthorized = err
-        .chain()
-        .any(|cause| cause.downcast_ref::<PublisherError>().is_some_and(PublisherError::is_unauthorized));
+    let unauthorized = err.chain().any(|cause| {
+        cause
+            .downcast_ref::<PublisherError>()
+            .is_some_and(PublisherError::is_unauthorized)
+    });
 
     if unauthorized {
         anyhow!("{err:#}\n\n{}", wallet_daemon_auth_help(had_api_key))
@@ -223,9 +227,9 @@ pub struct CommonArguments {
 
     /// API key used to authenticate with the wallet daemon.
     /// Sent as a bearer token on every JSON-RPC request. The key must be minted
-    /// with at least `templates:read`, `templates:create` and `accounts:read`
-    /// permissions. Can also be set via the `TARI_WALLET_DAEMON_API_KEY`
-    /// environment variable.
+    /// with at least `templates:read`, `templates:create`, `accounts:read` and
+    /// `transactions:read` permissions. Can also be set via the
+    /// `TARI_WALLET_DAEMON_API_KEY` environment variable.
     #[arg(
         long,
         value_name = "API_KEY",

--- a/crates/cli/src/cli/command.rs
+++ b/crates/cli/src/cli/command.rs
@@ -25,7 +25,8 @@ use clap::{
 };
 use convert_case::{Case, Casing};
 use ootle_network::Network;
-use std::{env, path::PathBuf};
+use std::{convert::Infallible, env, path::PathBuf};
+use tari_utilities::Hidden;
 
 const DEFAULT_DATA_FOLDER_NAME: &str = "tari_cli";
 const TEMPLATE_REPOS_FOLDER_NAME: &str = "template_repositories";
@@ -115,6 +116,12 @@ fn parse_network(s: &str) -> Result<Network, String> {
     s.parse().map_err(|e: ootle_network::NetworkParseError| e.to_string())
 }
 
+/// Wraps a raw API key (from `--api-key` or `TARI_WALLET_DAEMON_API_KEY`) in
+/// [`Hidden`] so it is zeroized on drop and kept out of `Debug` output.
+fn parse_api_key(value: &str) -> Result<Hidden<String>, Infallible> {
+    Ok(Hidden::hide(value.to_string()))
+}
+
 #[derive(Clone, Debug)]
 pub struct ConfigOverride {
     pub key: String,
@@ -150,9 +157,10 @@ pub struct CommonArguments {
         value_name = "API_KEY",
         env = "TARI_WALLET_DAEMON_API_KEY",
         hide_env_values = true,
+        value_parser = parse_api_key,
         global = true
     )]
-    api_key: Option<String>,
+    api_key: Option<Hidden<String>>,
 }
 
 #[derive(Clone, Parser)]
@@ -321,7 +329,8 @@ impl Cli {
         match &command {
             Command::Template { .. } | Command::Publish { .. } | Command::Metadata { .. } => {
                 let network_override = self.args.network;
-                let api_key = self.args.api_key.clone();
+                // Move the key out rather than clone, so no extra plaintext copy lingers.
+                let api_key = self.args.api_key.take();
                 return match command {
                     Command::Template { command } => match command {
                         TemplateCommand::Init { args } => template::init_metadata::handle(args).await,

--- a/crates/cli/src/cli/command.rs
+++ b/crates/cli/src/cli/command.rs
@@ -139,6 +139,20 @@ pub struct CommonArguments {
     /// (e.g. `esmeralda`, `igor`, `localnet`, `mainnet`)
     #[arg(short = 'n', long, value_name = "NETWORK", value_parser = parse_network, global = true)]
     network: Option<Network>,
+
+    /// API key used to authenticate with the wallet daemon.
+    /// Sent as a bearer token on every JSON-RPC request. The key must be minted
+    /// with at least `template:read`, `template:write` and `account:read`
+    /// permissions. Can also be set via the `TARI_WALLET_DAEMON_API_KEY`
+    /// environment variable.
+    #[arg(
+        long,
+        value_name = "API_KEY",
+        env = "TARI_WALLET_DAEMON_API_KEY",
+        hide_env_values = true,
+        global = true
+    )]
+    api_key: Option<String>,
 }
 
 #[derive(Clone, Parser)]
@@ -307,18 +321,19 @@ impl Cli {
         match &command {
             Command::Template { .. } | Command::Publish { .. } | Command::Metadata { .. } => {
                 let network_override = self.args.network;
+                let api_key = self.args.api_key.clone();
                 return match command {
                     Command::Template { command } => match command {
                         TemplateCommand::Init { args } => template::init_metadata::handle(args).await,
                         TemplateCommand::Inspect { args } => template::inspect_metadata::handle(args).await,
                         TemplateCommand::Publish { args } => {
-                            template::publish::handle(config, network_override, args).await
+                            template::publish::handle(config, network_override, api_key, args).await
                         },
                     },
-                    Command::Publish { args } => publish::handle(config, network_override, args).await,
+                    Command::Publish { args } => publish::handle(config, network_override, api_key, args).await,
                     Command::Metadata { command } => match command {
                         MetadataCommand::Publish { args } => {
-                            metadata::publish::handle(config, network_override, args).await
+                            metadata::publish::handle(config, network_override, api_key, args).await
                         },
                         MetadataCommand::Inspect { .. } => unreachable!(),
                     },

--- a/crates/cli/src/cli/command.rs
+++ b/crates/cli/src/cli/command.rs
@@ -142,7 +142,7 @@ pub struct CommonArguments {
 
     /// API key used to authenticate with the wallet daemon.
     /// Sent as a bearer token on every JSON-RPC request. The key must be minted
-    /// with at least `template:read`, `template:write` and `account:read`
+    /// with at least `templates:read`, `templates:create` and `accounts:read`
     /// permissions. Can also be set via the `TARI_WALLET_DAEMON_API_KEY`
     /// environment variable.
     #[arg(

--- a/crates/cli/src/cli/commands/metadata/publish.rs
+++ b/crates/cli/src/cli/commands/metadata/publish.rs
@@ -64,6 +64,7 @@ pub struct PublishMetadataArgs {
 pub async fn handle(
     config: Config,
     network_override: Option<Network>,
+    api_key: Option<String>,
     args: PublishMetadataArgs,
 ) -> anyhow::Result<()> {
     let cbor_path = find_metadata_cbor(&args.path).await?;
@@ -75,7 +76,7 @@ pub async fn handle(
         resolve_wallet_daemon_url(args.wallet_daemon_url.as_ref(), &project_config, &config, network);
     println!("🌐 Network: {network}");
 
-    let publisher = TemplatePublisher::new(NetworkConfig::new(wallet_daemon_url));
+    let publisher = TemplatePublisher::new(NetworkConfig::new(wallet_daemon_url).with_api_key(api_key));
 
     // Resolve metadata server URL: CLI flag > project config > global config > default for network
     let metadata_server_url = args

--- a/crates/cli/src/cli/commands/metadata/publish.rs
+++ b/crates/cli/src/cli/commands/metadata/publish.rs
@@ -17,6 +17,7 @@ use tari_engine_types::published_template::PublishedTemplateAddress;
 use tari_ootle_publish_lib::NetworkConfig;
 use tari_ootle_publish_lib::publisher::{SignedMetadataPayload, TemplatePublisher};
 use tari_ootle_template_metadata::TemplateMetadata;
+use tari_utilities::Hidden;
 use url::Url;
 
 /// Default retry settings: 6 attempts, 10s initial backoff (10, 20, 40, 80, 160s ≈ ~5 min total).
@@ -64,7 +65,7 @@ pub struct PublishMetadataArgs {
 pub async fn handle(
     config: Config,
     network_override: Option<Network>,
-    api_key: Option<String>,
+    api_key: Option<Hidden<String>>,
     args: PublishMetadataArgs,
 ) -> anyhow::Result<()> {
     let cbor_path = find_metadata_cbor(&args.path).await?;

--- a/crates/cli/src/cli/commands/publish.rs
+++ b/crates/cli/src/cli/commands/publish.rs
@@ -86,7 +86,12 @@ pub async fn build_template(crate_dir: &Path) -> anyhow::Result<PathBuf> {
 }
 
 /// `tari publish` delegates to `tari template publish` — they behave identically.
-pub async fn handle(config: Config, network_override: Option<Network>, args: PublishArgs) -> anyhow::Result<()> {
+pub async fn handle(
+    config: Config,
+    network_override: Option<Network>,
+    api_key: Option<String>,
+    args: PublishArgs,
+) -> anyhow::Result<()> {
     let template_args = TemplatePublishArgs {
         path: args.path,
         account: args.account,
@@ -98,7 +103,7 @@ pub async fn handle(config: Config, network_override: Option<Network>, args: Pub
         publish_metadata: args.publish_metadata,
         metadata_server_url: args.metadata_server_url,
     };
-    crate::cli::commands::template::publish::handle(config, network_override, template_args).await
+    crate::cli::commands::template::publish::handle(config, network_override, api_key, template_args).await
 }
 
 async fn build_project(dir: &Path, name: &str) -> anyhow::Result<PathBuf> {

--- a/crates/cli/src/cli/commands/publish.rs
+++ b/crates/cli/src/cli/commands/publish.rs
@@ -13,6 +13,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use tari_ootle_publish_lib::walletd_client::ComponentAddressOrName;
 use tari_ootle_template_metadata::TemplateMetadata;
+use tari_utilities::Hidden;
 use tokio::fs;
 use tokio::process::Command;
 
@@ -89,7 +90,7 @@ pub async fn build_template(crate_dir: &Path) -> anyhow::Result<PathBuf> {
 pub async fn handle(
     config: Config,
     network_override: Option<Network>,
-    api_key: Option<String>,
+    api_key: Option<Hidden<String>>,
     args: PublishArgs,
 ) -> anyhow::Result<()> {
     let template_args = TemplatePublishArgs {

--- a/crates/cli/src/cli/commands/template/publish.rs
+++ b/crates/cli/src/cli/commands/template/publish.rs
@@ -11,6 +11,7 @@ use tari_engine_types::published_template::PublishedTemplateAddress;
 use tari_ootle_publish_lib::NetworkConfig;
 use tari_ootle_publish_lib::publisher::{CheckBalanceResult, Template, TemplatePublisher};
 use tari_ootle_publish_lib::walletd_client::ComponentAddressOrName;
+use tari_utilities::Hidden;
 
 use crate::cli::commands::metadata::publish::publish_metadata_to_server;
 use crate::cli::commands::publish::{
@@ -69,7 +70,7 @@ pub struct TemplatePublishArgs {
 pub async fn handle(
     config: Config,
     network_override: Option<Network>,
-    api_key: Option<String>,
+    api_key: Option<Hidden<String>>,
     mut args: TemplatePublishArgs,
 ) -> anyhow::Result<()> {
     let crate_dir = &args.path;

--- a/crates/cli/src/cli/commands/template/publish.rs
+++ b/crates/cli/src/cli/commands/template/publish.rs
@@ -69,6 +69,7 @@ pub struct TemplatePublishArgs {
 pub async fn handle(
     config: Config,
     network_override: Option<Network>,
+    api_key: Option<String>,
     mut args: TemplatePublishArgs,
 ) -> anyhow::Result<()> {
     let crate_dir = &args.path;
@@ -139,7 +140,7 @@ pub async fn handle(
     };
 
     // Connect to wallet daemon
-    let publisher = TemplatePublisher::new(NetworkConfig::new(wallet_daemon_url.clone()));
+    let publisher = TemplatePublisher::new(NetworkConfig::new(wallet_daemon_url.clone()).with_api_key(api_key));
     let info = publisher
         .get_wallet_info()
         .await

--- a/crates/publish_lib/Cargo.toml
+++ b/crates/publish_lib/Cargo.toml
@@ -15,6 +15,7 @@ tari_engine_types = { workspace = true }
 tari_template_lib_types = { workspace = true }
 tari_ootle_template_metadata = { workspace = true }
 tari_ootle_wallet_sdk = { workspace = true }
+tari_utilities = { workspace = true }
 ootle_serde = { workspace = true, features = ["hex"] }
 
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }

--- a/crates/publish_lib/src/config.rs
+++ b/crates/publish_lib/src/config.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use serde::{Deserialize, Serialize};
+use tari_utilities::Hidden;
 use url::Url;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -13,9 +14,12 @@ pub struct NetworkConfig {
     /// API key used to authenticate with the wallet daemon. Sent as a bearer
     /// token on every JSON-RPC request. `None` sends no `Authorization` header,
     /// which only works against a daemon with authentication disabled.
-    // Never persisted: a secret must not be written to a config file on disk.
+    //
+    // Wrapped in `Hidden` so it is zeroized from memory on drop and never
+    // exposed through `Debug`. Never persisted either: `#[serde(skip)]` keeps
+    // the secret out of any config file written to disk.
     #[serde(skip)]
-    api_key: Option<String>,
+    api_key: Option<Hidden<String>>,
 }
 
 impl NetworkConfig {
@@ -27,7 +31,7 @@ impl NetworkConfig {
     }
 
     /// Sets the wallet daemon API key used for authentication.
-    pub fn with_api_key(mut self, api_key: Option<String>) -> Self {
+    pub fn with_api_key(mut self, api_key: Option<Hidden<String>>) -> Self {
         self.api_key = api_key;
         self
     }
@@ -37,6 +41,6 @@ impl NetworkConfig {
     }
 
     pub fn api_key(&self) -> Option<&str> {
-        self.api_key.as_deref()
+        self.api_key.as_ref().map(|key| key.reveal().as_str())
     }
 }

--- a/crates/publish_lib/src/config.rs
+++ b/crates/publish_lib/src/config.rs
@@ -10,16 +10,33 @@ pub struct NetworkConfig {
     /// HTTP address of Tari Layer-2 wallet daemon's JRPC (JSON-RPC) endpoint.
     /// Example: http://127.0.0.1:12047
     wallet_daemon_jrpc_address: Url,
+    /// API key used to authenticate with the wallet daemon. Sent as a bearer
+    /// token on every JSON-RPC request. `None` sends no `Authorization` header,
+    /// which only works against a daemon with authentication disabled.
+    // Never persisted: a secret must not be written to a config file on disk.
+    #[serde(skip)]
+    api_key: Option<String>,
 }
 
 impl NetworkConfig {
     pub fn new(wallet_daemon_jrpc_address: Url) -> Self {
         Self {
             wallet_daemon_jrpc_address,
+            api_key: None,
         }
+    }
+
+    /// Sets the wallet daemon API key used for authentication.
+    pub fn with_api_key(mut self, api_key: Option<String>) -> Self {
+        self.api_key = api_key;
+        self
     }
 
     pub fn wallet_daemon_jrpc_address(&self) -> &Url {
         &self.wallet_daemon_jrpc_address
+    }
+
+    pub fn api_key(&self) -> Option<&str> {
+        self.api_key.as_deref()
     }
 }

--- a/crates/publish_lib/src/error.rs
+++ b/crates/publish_lib/src/error.rs
@@ -36,6 +36,4 @@ pub enum Error {
     WasmOptimizationError(#[from] crate::wasm_opt::Error),
     #[error("Invalid response: {0}")]
     InvalidResponse(String),
-    #[error("Unsupported operation: {0}")]
-    NotSupportedError(String),
 }

--- a/crates/publish_lib/src/error.rs
+++ b/crates/publish_lib/src/error.rs
@@ -37,3 +37,11 @@ pub enum Error {
     #[error("Invalid response: {0}")]
     InvalidResponse(String),
 }
+
+impl Error {
+    /// Returns `true` if this error was caused by a failed or missing wallet
+    /// daemon authentication (an HTTP 401 "Unauthorized" response).
+    pub fn is_unauthorized(&self) -> bool {
+        matches!(self, Self::WalletDaemonClient(e) if e.is_unauthorized())
+    }
+}

--- a/crates/publish_lib/src/publisher.rs
+++ b/crates/publish_lib/src/publisher.rs
@@ -290,8 +290,8 @@ impl TemplatePublisher {
     ///
     /// When an API key is configured it is sent as the `Authorization: Bearer`
     /// token on every request — no `auth.request` round-trip is performed. The
-    /// key must be minted with at least the `template:read`, `template:write`
-    /// and `account:read` permissions for publishing to succeed.
+    /// key must be minted with at least the `templates:read`, `templates:create`
+    /// and `accounts:read` permissions for publishing to succeed.
     pub async fn wallet_daemon_client(&self) -> Result<WalletDaemonClient> {
         let token = self
             .network

--- a/crates/publish_lib/src/publisher.rs
+++ b/crates/publish_lib/src/publisher.rs
@@ -290,8 +290,9 @@ impl TemplatePublisher {
     ///
     /// When an API key is configured it is sent as the `Authorization: Bearer`
     /// token on every request — no `auth.request` round-trip is performed. The
-    /// key must be minted with at least the `templates:read`, `templates:create`
-    /// and `accounts:read` permissions for publishing to succeed.
+    /// key must be minted with at least the `templates:read`, `templates:create`,
+    /// `accounts:read` and `transactions:read` permissions for publishing to
+    /// succeed (publishing waits on the transaction result to confirm).
     pub async fn wallet_daemon_client(&self) -> Result<WalletDaemonClient> {
         let token = self
             .network

--- a/crates/publish_lib/src/publisher.rs
+++ b/crates/publish_lib/src/publisher.rs
@@ -15,11 +15,9 @@ use tari_engine_types::substate::SubstateId;
 use tari_ootle_common_types::optional::Optional;
 use tari_ootle_template_metadata::MetadataHash;
 use tari_ootle_template_metadata::TemplateMetadata;
-use tari_ootle_walletd_client::permissions::Permission;
 use tari_ootle_walletd_client::types::{
-    AccountsGetBalancesRequest, AuthCredentials, AuthGetMethodResponse, AuthLoginRequest, AuthLoginResponse,
-    AuthMethod, PublishTemplateMetadata, PublishTemplateRequest, SignTemplateMetadataRequest,
-    SignTemplateMetadataResponse, TransactionWaitResultRequest, WalletGetInfoResponse,
+    AccountsGetBalancesRequest, EncodedJwtString, PublishTemplateMetadata, PublishTemplateRequest,
+    SignTemplateMetadataRequest, SignTemplateMetadataResponse, TransactionWaitResultRequest, WalletGetInfoResponse,
 };
 use tari_ootle_walletd_client::{ComponentAddressOrName, WalletDaemonClient};
 use tari_template_lib_types::Hash32;
@@ -289,28 +287,17 @@ impl TemplatePublisher {
     }
 
     /// Returns a new wallet daemon client.
+    ///
+    /// When an API key is configured it is sent as the `Authorization: Bearer`
+    /// token on every request — no `auth.request` round-trip is performed. The
+    /// key must be minted with at least the `template:read`, `template:write`
+    /// and `account:read` permissions for publishing to succeed.
     pub async fn wallet_daemon_client(&self) -> Result<WalletDaemonClient> {
-        let mut client = WalletDaemonClient::connect(self.network.wallet_daemon_jrpc_address().clone(), None)?;
-
-        let AuthGetMethodResponse { method } = client.get_auth_method().await?;
-        let credentials = match method {
-            AuthMethod::None => AuthCredentials::None,
-            AuthMethod::Webauthn => {
-                return Err(Error::NotSupportedError(
-                    "Webauthn is not currently supported".to_string(),
-                ));
-            },
-        };
-        // authentication
-        let AuthLoginResponse { token } = client
-            .auth_request(AuthLoginRequest {
-                permissions: vec![Permission::Admin],
-                credentials,
-            })
-            .await?;
-
-        client.set_auth_token(token);
-
+        let token = self
+            .network
+            .api_key()
+            .map(|key| EncodedJwtString::from(key.to_string()));
+        let client = WalletDaemonClient::connect(self.network.wallet_daemon_jrpc_address().clone(), token)?;
         Ok(client)
     }
 }

--- a/docs/01-getting-started/installation.md
+++ b/docs/01-getting-started/installation.md
@@ -120,7 +120,7 @@ Expected response: `{"jsonrpc":"2.0","result":{"network":"igor","network_byte":3
 
 **API key**:
 
-When the wallet daemon has authentication enabled, the CLI authenticates with an API key issued by the daemon. Mint a key with at least the `templates:read`, `templates:create` and `accounts:read` permissions, then make it available to the CLI:
+When the wallet daemon has authentication enabled, the CLI authenticates with an API key issued by the daemon. Mint a key with at least the `templates:read`, `templates:create`, `accounts:read` and `transactions:read` permissions, then make it available to the CLI:
 
 ```bash
 export TARI_WALLET_DAEMON_API_KEY="<your-api-key>"

--- a/docs/01-getting-started/installation.md
+++ b/docs/01-getting-started/installation.md
@@ -118,6 +118,16 @@ curl -X POST http://127.0.0.1:9000/ \
 
 Expected response: `{"jsonrpc":"2.0","result":{"network":"igor","network_byte":36,"version":"0.10.4"},"id":1}`
 
+**API key**:
+
+When the wallet daemon has authentication enabled, the CLI authenticates with an API key issued by the daemon. Mint a key with at least the `template:read`, `template:write` and `account:read` permissions, then make it available to the CLI:
+
+```bash
+export TARI_WALLET_DAEMON_API_KEY="<your-api-key>"
+```
+
+You can also pass it per command with `--api-key`. The key is sent as a bearer token and is never stored in a config file.
+
 ## Verification
 
 Verify your installation is working correctly:

--- a/docs/01-getting-started/installation.md
+++ b/docs/01-getting-started/installation.md
@@ -120,7 +120,7 @@ Expected response: `{"jsonrpc":"2.0","result":{"network":"igor","network_byte":3
 
 **API key**:
 
-When the wallet daemon has authentication enabled, the CLI authenticates with an API key issued by the daemon. Mint a key with at least the `template:read`, `template:write` and `account:read` permissions, then make it available to the CLI:
+When the wallet daemon has authentication enabled, the CLI authenticates with an API key issued by the daemon. Mint a key with at least the `templates:read`, `templates:create` and `accounts:read` permissions, then make it available to the CLI:
 
 ```bash
 export TARI_WALLET_DAEMON_API_KEY="<your-api-key>"

--- a/docs/01-getting-started/quick-start.md
+++ b/docs/01-getting-started/quick-start.md
@@ -18,6 +18,7 @@ blockchain deployment.
 
 - ✅ **Tari CLI installed** ([Installation Guide](installation.md))
 - ✅ **Tari Wallet Daemon running** on `http://127.0.0.1:9000/`
+- ✅ **Wallet daemon API key** exported as `TARI_WALLET_DAEMON_API_KEY` (with `template:read`, `template:write`, `account:read` permissions) — needed for publishing
 - ✅ **Rust with WASM target** (`rustup target add wasm32-unknown-unknown`)
 
 ## Step 1: Create Your Project

--- a/docs/01-getting-started/quick-start.md
+++ b/docs/01-getting-started/quick-start.md
@@ -18,7 +18,7 @@ blockchain deployment.
 
 - ✅ **Tari CLI installed** ([Installation Guide](installation.md))
 - ✅ **Tari Wallet Daemon running** on `http://127.0.0.1:9000/`
-- ✅ **Wallet daemon API key** exported as `TARI_WALLET_DAEMON_API_KEY` (with `template:read`, `template:write`, `account:read` permissions) — needed for publishing
+- ✅ **Wallet daemon API key** exported as `TARI_WALLET_DAEMON_API_KEY` (with `templates:read`, `templates:create`, `accounts:read` permissions) — needed for publishing
 - ✅ **Rust with WASM target** (`rustup target add wasm32-unknown-unknown`)
 
 ## Step 1: Create Your Project

--- a/docs/01-getting-started/quick-start.md
+++ b/docs/01-getting-started/quick-start.md
@@ -18,7 +18,7 @@ blockchain deployment.
 
 - ✅ **Tari CLI installed** ([Installation Guide](installation.md))
 - ✅ **Tari Wallet Daemon running** on `http://127.0.0.1:9000/`
-- ✅ **Wallet daemon API key** exported as `TARI_WALLET_DAEMON_API_KEY` (with `templates:read`, `templates:create`, `accounts:read` permissions) — needed for publishing
+- ✅ **Wallet daemon API key** exported as `TARI_WALLET_DAEMON_API_KEY` (with `templates:read`, `templates:create`, `accounts:read`, `transactions:read` permissions) — needed for publishing
 - ✅ **Rust with WASM target** (`rustup target add wasm32-unknown-unknown`)
 
 ## Step 1: Create Your Project

--- a/docs/02-guides/architecture.md
+++ b/docs/02-guides/architecture.md
@@ -390,12 +390,12 @@ graph LR
     Wallet --> Deploy[Deployment Access]
 ```
 
-The API key is supplied via the `--api-key` flag or the `TARI_WALLET_DAEMON_API_KEY` environment variable, and must carry the `template:read`, `template:write` and `account:read` permissions.
+The API key is supplied via the `--api-key` flag or the `TARI_WALLET_DAEMON_API_KEY` environment variable, and must carry the `templates:read`, `templates:create` and `accounts:read` permissions.
 
 ### Security Considerations
 
 1. **API Key Authentication**: Bearer token sent to the wallet daemon
-2. **Scoped Permissions**: Key minted with only `template:read`, `template:write`, `account:read`
+2. **Scoped Permissions**: Key minted with only `templates:read`, `templates:create`, `accounts:read`
 3. **HTTPS Support**: Secure network communication
 4. **Input Validation**: Parameter and configuration validation
 5. **Secret Management**: API key is never stored in CLI configuration (flag or env var only)

--- a/docs/02-guides/architecture.md
+++ b/docs/02-guides/architecture.md
@@ -381,21 +381,24 @@ async fn main() -> anyhow::Result<()> {
 
 ### Authentication Flow
 
+The CLI authenticates with the wallet daemon using an API key, sent as an `Authorization: Bearer` token on every JSON-RPC request. There is no interactive login round-trip.
+
 ```mermaid
 graph LR
-    CLI[CLI] --> Wallet[Wallet Daemon]
-    Wallet --> Auth[Authentication]
-    Auth --> Admin[Admin Permissions]
-    Admin --> Deploy[Deployment Access]
+    CLI[CLI] --> ApiKey[API Key]
+    ApiKey --> |Authorization: Bearer| Wallet[Wallet Daemon]
+    Wallet --> Deploy[Deployment Access]
 ```
+
+The API key is supplied via the `--api-key` flag or the `TARI_WALLET_DAEMON_API_KEY` environment variable, and must carry the `template:read`, `template:write` and `account:read` permissions.
 
 ### Security Considerations
 
-1. **Wallet Authentication**: Secure connection to wallet daemon
-2. **Admin Permissions**: Required for template deployment
+1. **API Key Authentication**: Bearer token sent to the wallet daemon
+2. **Scoped Permissions**: Key minted with only `template:read`, `template:write`, `account:read`
 3. **HTTPS Support**: Secure network communication
 4. **Input Validation**: Parameter and configuration validation
-5. **Secret Management**: No secrets stored in CLI configuration
+5. **Secret Management**: API key is never stored in CLI configuration (flag or env var only)
 
 ## Extension Points
 

--- a/docs/02-guides/architecture.md
+++ b/docs/02-guides/architecture.md
@@ -390,12 +390,12 @@ graph LR
     Wallet --> Deploy[Deployment Access]
 ```
 
-The API key is supplied via the `--api-key` flag or the `TARI_WALLET_DAEMON_API_KEY` environment variable, and must carry the `templates:read`, `templates:create` and `accounts:read` permissions.
+The API key is supplied via the `--api-key` flag or the `TARI_WALLET_DAEMON_API_KEY` environment variable, and must carry the `templates:read`, `templates:create`, `accounts:read` and `transactions:read` permissions.
 
 ### Security Considerations
 
 1. **API Key Authentication**: Bearer token sent to the wallet daemon
-2. **Scoped Permissions**: Key minted with only `templates:read`, `templates:create`, `accounts:read`
+2. **Scoped Permissions**: Key minted with only `templates:read`, `templates:create`, `accounts:read`, `transactions:read`
 3. **HTTPS Support**: Secure network communication
 4. **Input Validation**: Parameter and configuration validation
 5. **Secret Management**: API key is never stored in CLI configuration (flag or env var only)

--- a/docs/02-guides/project-configuration.md
+++ b/docs/02-guides/project-configuration.md
@@ -176,7 +176,7 @@ Options:
 1. **Tari Wallet Daemon**: Must be running and accessible
     - Download from: https://github.com/tari-project/tari-dan
     - Default address: `http://127.0.0.1:5100/json_rpc`
-    - Requires an API key (`--api-key` or `TARI_WALLET_DAEMON_API_KEY`) with `template:read`, `template:write` and `account:read` permissions
+    - Requires an API key (`--api-key` or `TARI_WALLET_DAEMON_API_KEY`) with `templates:read`, `templates:create` and `accounts:read` permissions
 
 2. **Rust Toolchain**: Required for template compilation
     - Install: `rustup target add wasm32-unknown-unknown`

--- a/docs/02-guides/project-configuration.md
+++ b/docs/02-guides/project-configuration.md
@@ -176,7 +176,7 @@ Options:
 1. **Tari Wallet Daemon**: Must be running and accessible
     - Download from: https://github.com/tari-project/tari-dan
     - Default address: `http://127.0.0.1:5100/json_rpc`
-    - Requires authentication with Admin permissions
+    - Requires an API key (`--api-key` or `TARI_WALLET_DAEMON_API_KEY`) with `template:read`, `template:write` and `account:read` permissions
 
 2. **Rust Toolchain**: Required for template compilation
     - Install: `rustup target add wasm32-unknown-unknown`

--- a/docs/02-guides/project-configuration.md
+++ b/docs/02-guides/project-configuration.md
@@ -176,7 +176,7 @@ Options:
 1. **Tari Wallet Daemon**: Must be running and accessible
     - Download from: https://github.com/tari-project/tari-dan
     - Default address: `http://127.0.0.1:5100/json_rpc`
-    - Requires an API key (`--api-key` or `TARI_WALLET_DAEMON_API_KEY`) with `templates:read`, `templates:create` and `accounts:read` permissions
+    - Requires an API key (`--api-key` or `TARI_WALLET_DAEMON_API_KEY`) with `templates:read`, `templates:create`, `accounts:read` and `transactions:read` permissions
 
 2. **Rust Toolchain**: Required for template compilation
     - Install: `rustup target add wasm32-unknown-unknown`

--- a/docs/03-reference/cli-commands.md
+++ b/docs/03-reference/cli-commands.md
@@ -47,9 +47,9 @@ The key must be minted with at least these permissions for the CLI to work:
 
 | Permission | Used for |
 |------------|----------|
-| `template:read` | Reading template state |
-| `template:write` | Publishing templates and signing metadata |
-| `account:read` | Resolving the fee account and checking its balance |
+| `templates:read` | Reading template state |
+| `templates:create` | Publishing templates and signing metadata |
+| `accounts:read` | Resolving the fee account and checking its balance |
 
 If the wallet daemon has authentication disabled, the API key may be omitted.
 

--- a/docs/03-reference/cli-commands.md
+++ b/docs/03-reference/cli-commands.md
@@ -25,6 +25,33 @@ tari [GLOBAL_OPTIONS] <COMMAND> [COMMAND_OPTIONS]
 | `--config-file-path <PATH>` | `-c` | Config file location | `~/.config/tari_cli/tari.config.toml` |
 | `--config-overrides <KEY=VALUE>` | `-e` | Config file overrides (e.g. `networks.esmeralda.wallet-daemon-url=...`) | None |
 | `--network <NETWORK>` | `-n` | Active network (`esmeralda`, `localnet`, `igor`, `nextnet`, `stagenet`, `mainnet`). Overrides project and global `default-network` | Project / global default |
+| `--api-key <API_KEY>` | | Wallet daemon API key, sent as a bearer token. Also read from `TARI_WALLET_DAEMON_API_KEY` | `$TARI_WALLET_DAEMON_API_KEY` |
+
+### Wallet daemon authentication
+
+Commands that talk to the wallet daemon (`publish`, `template publish`, and `metadata publish --signed`) authenticate with an **API key** issued by the wallet daemon. The key is sent as an `Authorization: Bearer` token on every JSON-RPC request — there is no interactive login.
+
+Provide the key with the `--api-key` flag or the `TARI_WALLET_DAEMON_API_KEY` environment variable (the flag takes precedence):
+
+```bash
+export TARI_WALLET_DAEMON_API_KEY="<your-api-key>"
+tari publish -a myaccount
+
+# or per-invocation
+tari publish -a myaccount --api-key "<your-api-key>"
+```
+
+For security, the API key is **never** read from or written to a config file.
+
+The key must be minted with at least these permissions for the CLI to work:
+
+| Permission | Used for |
+|------------|----------|
+| `template:read` | Reading template state |
+| `template:write` | Publishing templates and signing metadata |
+| `account:read` | Resolving the fee account and checking its balance |
+
+If the wallet daemon has authentication disabled, the API key may be omitted.
 
 ## Commands Overview
 
@@ -141,6 +168,7 @@ tari publish [OPTIONS] [PATH]
 | `-f, --max-fee` | u64 | Auto-estimated | Maximum fee in microtari |
 | `--binary, --bin` | Path | *builds if not set* | Path to pre-compiled WASM binary |
 | `--wallet-daemon-url` | URL | `[networks.<active>].wallet-daemon-url` | Wallet daemon JSON-RPC URL |
+| `--api-key` | String | `$TARI_WALLET_DAEMON_API_KEY` | Wallet daemon API key (bearer token) |
 | `--publish-metadata` | Flag | `false` | Auto-submit metadata to server after publishing |
 | `--metadata-server-url` | URL | `[networks.<active>].metadata-server-url` | Metadata server URL (with `--publish-metadata`) |
 
@@ -239,6 +267,7 @@ tari metadata publish [OPTIONS] [-t <TEMPLATE_ADDRESS>]
 | `--signed` | Flag | `false` | Use author-signed submission via wallet daemon |
 | `--key-index` | u64 | `0` | Derived account key index (with `--signed`) |
 | `--wallet-daemon-url` | URL | `[networks.<active>].wallet-daemon-url` | Wallet daemon URL (with `--signed`) |
+| `--api-key` | String | `$TARI_WALLET_DAEMON_API_KEY` | Wallet daemon API key (bearer token, with `--signed`) |
 
 #### Hash-verified (default)
 
@@ -328,6 +357,7 @@ The active network is resolved first, then per-setting values are read from that
 | Metadata server URL | `--metadata-server-url` | `networks.<active>.metadata-server-url` | `networks.<active>.metadata-server-url` | esmeralda → `https://ootle-templates-esme.tari.com/`, localnet → `http://localhost:3000/`, others → none |
 | Template address | `--template-address` | `networks.<active>.template-address` | — | — |
 | Account | `--account` | `default-account` | `default-account` | Wallet daemon default |
+| Wallet daemon API key | `--api-key` | — (never stored in config) | — (never stored in config) | `TARI_WALLET_DAEMON_API_KEY` env var |
 
 ---
 

--- a/docs/03-reference/cli-commands.md
+++ b/docs/03-reference/cli-commands.md
@@ -50,6 +50,7 @@ The key must be minted with at least these permissions for the CLI to work:
 | `templates:read` | Reading template state |
 | `templates:create` | Publishing templates and signing metadata |
 | `accounts:read` | Resolving the fee account and checking its balance |
+| `transactions:read` | Waiting on the publish transaction result to confirm it |
 
 If the wallet daemon has authentication disabled, the API key may be omitted.
 

--- a/docs/04-troubleshooting/common-issues.md
+++ b/docs/04-troubleshooting/common-issues.md
@@ -229,18 +229,28 @@ curl -X POST http://127.0.0.1:9000/ \
 **Error Messages**:
 ```
 Authentication failed
-Insufficient permissions for admin operations
+Insufficient permissions
 ```
+
+The CLI authenticates with the wallet daemon using an **API key** sent as a bearer token. There is no interactive login.
 
 **Solutions**:
 
-1. **Verify Admin Access**:
+1. **Provide an API key**:
    ```bash
-   # Ensure wallet daemon is configured for admin operations
-   # Check wallet daemon startup logs for authentication setup
+   # Via environment variable
+   export TARI_WALLET_DAEMON_API_KEY="<your-api-key>"
+
+   # ...or per command
+   tari publish --api-key "<your-api-key>" -a myaccount
    ```
 
-2. **Check Account Configuration**:
+2. **Check the key's permissions**:
+
+   Mint the key with at least `template:read`, `template:write` and `account:read`.
+   Missing any of these causes an "insufficient permissions" error.
+
+3. **Check Account Configuration**:
    ```bash
    # Verify account exists in wallet daemon
    # Account names are case-sensitive

--- a/docs/04-troubleshooting/common-issues.md
+++ b/docs/04-troubleshooting/common-issues.md
@@ -247,7 +247,7 @@ The CLI authenticates with the wallet daemon using an **API key** sent as a bear
 
 2. **Check the key's permissions**:
 
-   Mint the key with at least `templates:read`, `templates:create` and `accounts:read`.
+   Mint the key with at least `templates:read`, `templates:create`, `accounts:read` and `transactions:read`.
    Missing any of these causes an "insufficient permissions" error.
 
 3. **Check Account Configuration**:

--- a/docs/04-troubleshooting/common-issues.md
+++ b/docs/04-troubleshooting/common-issues.md
@@ -247,7 +247,7 @@ The CLI authenticates with the wallet daemon using an **API key** sent as a bear
 
 2. **Check the key's permissions**:
 
-   Mint the key with at least `template:read`, `template:write` and `account:read`.
+   Mint the key with at least `templates:read`, `templates:create` and `accounts:read`.
    Missing any of these causes an "insufficient permissions" error.
 
 3. **Check Account Configuration**:

--- a/docs/04-troubleshooting/faq.md
+++ b/docs/04-troubleshooting/faq.md
@@ -89,7 +89,7 @@ export TARI_WALLET_DAEMON_API_KEY="<your-api-key>"
 tari publish -a myaccount
 ```
 
-The key must be minted with at least the `templates:read`, `templates:create` and `accounts:read` permissions. It is never read from or written to a config file.
+The key must be minted with at least the `templates:read`, `templates:create`, `accounts:read` and `transactions:read` permissions. It is never read from or written to a config file.
 
 ## 📁 Projects & Templates
 

--- a/docs/04-troubleshooting/faq.md
+++ b/docs/04-troubleshooting/faq.md
@@ -89,7 +89,7 @@ export TARI_WALLET_DAEMON_API_KEY="<your-api-key>"
 tari publish -a myaccount
 ```
 
-The key must be minted with at least the `template:read`, `template:write` and `account:read` permissions. It is never read from or written to a config file.
+The key must be minted with at least the `templates:read`, `templates:create` and `accounts:read` permissions. It is never read from or written to a config file.
 
 ## 📁 Projects & Templates
 

--- a/docs/04-troubleshooting/faq.md
+++ b/docs/04-troubleshooting/faq.md
@@ -80,6 +80,17 @@ cargo build --release --bin tari_wallet_daemon
 ./target/release/tari_wallet_daemon --network localnet
 ```
 
+### Q: How does the CLI authenticate with the wallet daemon?
+
+**A**: With an **API key** issued by the wallet daemon, sent as a bearer token on every request (there is no interactive login). Provide it via the `--api-key` flag or the `TARI_WALLET_DAEMON_API_KEY` environment variable:
+
+```bash
+export TARI_WALLET_DAEMON_API_KEY="<your-api-key>"
+tari publish -a myaccount
+```
+
+The key must be minted with at least the `template:read`, `template:write` and `account:read` permissions. It is never read from or written to a config file.
+
 ## 📁 Projects & Templates
 
 ### Q: What's the difference between project templates and WASM templates?

--- a/docs/src/content/docs/reference/publish.mdx
+++ b/docs/src/content/docs/reference/publish.mdx
@@ -30,6 +30,11 @@ This command publishes **without** a metadata hash. Use [`tari template publish`
 | `-y, --yes` | Auto-confirm publishing |
 | `-f, --max-fee <AMOUNT>` | Maximum fee in microtari |
 | `--binary <PATH>` | Path to pre-compiled WASM binary |
+| `--api-key <API_KEY>` | Wallet daemon API key (bearer token). Also read from `TARI_WALLET_DAEMON_API_KEY` |
+
+## Authentication
+
+Publishing authenticates with the wallet daemon using an **API key** sent as a bearer token. Provide it with `--api-key` or the `TARI_WALLET_DAEMON_API_KEY` environment variable. The key must be minted with at least the `template:read`, `template:write` and `account:read` permissions. The key is never read from or written to a config file.
 
 ## Examples
 
@@ -45,4 +50,8 @@ tari publish --binary target/wasm32-unknown-unknown/release/my_token.wasm
 
 # Auto-confirm with custom account
 tari publish -y -a my-account
+
+# Provide the wallet daemon API key via environment variable
+export TARI_WALLET_DAEMON_API_KEY="<your-api-key>"
+tari publish -a my-account
 ```

--- a/docs/src/content/docs/reference/publish.mdx
+++ b/docs/src/content/docs/reference/publish.mdx
@@ -34,7 +34,7 @@ This command publishes **without** a metadata hash. Use [`tari template publish`
 
 ## Authentication
 
-Publishing authenticates with the wallet daemon using an **API key** sent as a bearer token. Provide it with `--api-key` or the `TARI_WALLET_DAEMON_API_KEY` environment variable. The key must be minted with at least the `templates:read`, `templates:create` and `accounts:read` permissions. The key is never read from or written to a config file.
+Publishing authenticates with the wallet daemon using an **API key** sent as a bearer token. Provide it with `--api-key` or the `TARI_WALLET_DAEMON_API_KEY` environment variable. The key must be minted with at least the `templates:read`, `templates:create`, `accounts:read` and `transactions:read` permissions. The key is never read from or written to a config file.
 
 ## Examples
 

--- a/docs/src/content/docs/reference/publish.mdx
+++ b/docs/src/content/docs/reference/publish.mdx
@@ -34,7 +34,7 @@ This command publishes **without** a metadata hash. Use [`tari template publish`
 
 ## Authentication
 
-Publishing authenticates with the wallet daemon using an **API key** sent as a bearer token. Provide it with `--api-key` or the `TARI_WALLET_DAEMON_API_KEY` environment variable. The key must be minted with at least the `template:read`, `template:write` and `account:read` permissions. The key is never read from or written to a config file.
+Publishing authenticates with the wallet daemon using an **API key** sent as a bearer token. Provide it with `--api-key` or the `TARI_WALLET_DAEMON_API_KEY` environment variable. The key must be minted with at least the `templates:read`, `templates:create` and `accounts:read` permissions. The key is never read from or written to a config file.
 
 ## Examples
 

--- a/docs/src/content/docs/reference/template-publish.mdx
+++ b/docs/src/content/docs/reference/template-publish.mdx
@@ -28,7 +28,7 @@ tari template publish [PATH] [OPTIONS]
 
 ## Authentication
 
-Publishing authenticates with the wallet daemon using an **API key** sent as a bearer token. Provide it with `--api-key` or the `TARI_WALLET_DAEMON_API_KEY` environment variable. The key must be minted with at least the `template:read`, `template:write` and `account:read` permissions. The key is never read from or written to a config file.
+Publishing authenticates with the wallet daemon using an **API key** sent as a bearer token. Provide it with `--api-key` or the `TARI_WALLET_DAEMON_API_KEY` environment variable. The key must be minted with at least the `templates:read`, `templates:create` and `accounts:read` permissions. The key is never read from or written to a config file.
 
 ## Examples
 

--- a/docs/src/content/docs/reference/template-publish.mdx
+++ b/docs/src/content/docs/reference/template-publish.mdx
@@ -28,7 +28,7 @@ tari template publish [PATH] [OPTIONS]
 
 ## Authentication
 
-Publishing authenticates with the wallet daemon using an **API key** sent as a bearer token. Provide it with `--api-key` or the `TARI_WALLET_DAEMON_API_KEY` environment variable. The key must be minted with at least the `templates:read`, `templates:create` and `accounts:read` permissions. The key is never read from or written to a config file.
+Publishing authenticates with the wallet daemon using an **API key** sent as a bearer token. Provide it with `--api-key` or the `TARI_WALLET_DAEMON_API_KEY` environment variable. The key must be minted with at least the `templates:read`, `templates:create`, `accounts:read` and `transactions:read` permissions. The key is never read from or written to a config file.
 
 ## Examples
 

--- a/docs/src/content/docs/reference/template-publish.mdx
+++ b/docs/src/content/docs/reference/template-publish.mdx
@@ -24,6 +24,11 @@ tari template publish [PATH] [OPTIONS]
 | `-y, --yes` | Auto-confirm publishing |
 | `-f, --max-fee <AMOUNT>` | Maximum fee in microtari |
 | `--binary <PATH>` | Path to pre-compiled WASM binary |
+| `--api-key <API_KEY>` | Wallet daemon API key (bearer token). Also read from `TARI_WALLET_DAEMON_API_KEY` |
+
+## Authentication
+
+Publishing authenticates with the wallet daemon using an **API key** sent as a bearer token. Provide it with `--api-key` or the `TARI_WALLET_DAEMON_API_KEY` environment variable. The key must be minted with at least the `template:read`, `template:write` and `account:read` permissions. The key is never read from or written to a config file.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

The wallet daemon now allows clients to authenticate with API tokens. This PR replaces the CLI's JWT login flow with API key authentication.

- **Removed** the JWT flow in `TemplatePublisher::wallet_daemon_client` (`auth.method` + `auth.request` round-trip requesting `Admin` permissions). The CLI now sends the API key as an `Authorization: Bearer` token on every JSON-RPC request (no login round-trip).
- **Added** an `--api-key` global flag, also readable from the `TARI_WALLET_DAEMON_API_KEY` environment variable. The flag takes precedence; the env value is hidden from `--help`.
- The API key is **never** read from or written to a config file (`#[serde(skip)]` on `NetworkConfig`). If the daemon has auth disabled, the key may be omitted.
- Removed the now-unused `AuthMethod`/`AuthCredentials`/`AuthLogin*` plumbing and the dead `NotSupportedError` (Webauthn) branch.
- **Docs** updated (README, CLI reference, getting-started, troubleshooting/FAQ, architecture) to describe the new model.

The key must be minted with at least these permissions for the CLI to work:

| Permission | Used for |
|------------|----------|
| `templates:read` | Reading template state |
| `templates:write` | Publishing templates and signing metadata |
| `accounts:read` | Resolving the fee account and checking its balance |

## Test plan

- [x] `cargo build` (publish_lib + CLI)
- [x] `cargo test` (15 passing, 0 failing)
- [x] `cargo clippy` clean
- [x] `cargo fmt`
- [x] `tari --help` / `tari publish --help` show `--api-key` with env var; secret value hidden in help output
- [ ] Manual end-to-end publish against a wallet daemon with API-key auth enabled (requires a running daemon + key)

https://claude.ai/code/session_018pbw83soXHfbpnVpcinoa1

---
_Generated by [Claude Code](https://claude.ai/code/session_018pbw83soXHfbpnVpcinoa1)_