### PR TITLE
fix(ci): handle crates.io 404 in publish-if-new check

### DIFF
--- a/.github/scripts/publish-if-new.sh
+++ b/.github/scripts/publish-if-new.sh
@@ -16,9 +16,13 @@ if [ -z "$version" ] || [ "$version" = "null" ]; then
   exit 1
 fi
 
-status=$(curl -fsS -o /dev/null -w "%{http_code}" \
+# No `-f`/`--fail`: a 404 (version not yet published) is an expected status we
+# branch on below — `--fail` would make curl exit non-zero on a 404 and skip the
+# publish path. `-w` always reports the real code (and `000` if the request itself
+# fails); `|| true` just lets the script continue under `set -e` without it.
+status=$(curl -sS -o /dev/null -w "%{http_code}" \
   -H "User-Agent: github.com/tari-project/tari-cli publish workflow" \
-  "https://crates.io/api/v1/crates/$name/$version" || echo "000")
+  "https://crates.io/api/v1/crates/$name/$version" || true)
 
 case "$status" in
   200)


### PR DESCRIPTION
## Problem

The `v0.20.0` release tag triggered the publish workflow, which **failed**:

```
error: unexpected HTTP 404000 checking crates.io for tari_ootle_publish_lib 0.20.0
```

`publish-if-new.sh` checks crates.io for an existing `name/version` and branches on the HTTP status (`200` → skip, `404` → publish). It ran `curl` with `-f`/`--fail`, so a `404` (the version isn't published yet — precisely the case we *want* to publish) made curl exit non-zero. The `-w "%{http_code}"` still printed `404`, and the `|| echo "000"` fallback then appended `000`, yielding the bogus status `404000`, which fell through to the error branch.

## Fix

Drop `-f`. Without it, curl exits `0` on a `404` and `-w` reports the real code, so the `404 → publish` branch runs as intended. Verified against crates.io:

- `GET /api/v1/crates/tari_ootle_publish_lib/0.20.0` → `404` (not yet published)
- `GET /api/v1/crates/serde/1.0.0` → `200` (exists)

Both `tari_ootle_publish_lib` and `tari-ootle-cli` already exist on crates.io with prior versions, so publishing `0.20.0` only needs `publish-update` token scope.

## Retrying the release

After merge, re-run the publish via **workflow_dispatch on `main`** (the fixed script publishes `0.20.0` because it's absent from crates.io) — no need to move the `v0.20.0` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)