### PR TITLE
docs: update esmeralda metadata server URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ default-network = "esmeralda"
 
 [networks.esmeralda]
 wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
-metadata-server-url = "https://ootle-templates-esme.tari.com/"
+metadata-server-url = "https://ootle.tari.com/community-templates"
 
 [networks.localnet]
 wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"

--- a/docs/02-guides/project-configuration.md
+++ b/docs/02-guides/project-configuration.md
@@ -24,7 +24,7 @@ default-network = "esmeralda"
 
 [networks.esmeralda]
 wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
-metadata-server-url = "https://ootle-templates-esme.tari.com/"
+metadata-server-url = "https://ootle.tari.com/community-templates"
 
 [networks.localnet]
 wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"

--- a/docs/03-reference/cli-commands.md
+++ b/docs/03-reference/cli-commands.md
@@ -355,7 +355,7 @@ The active network is resolved first, then per-setting values are read from that
 | Setting | CLI flag | Project config | Global config | Default |
 |---------|----------|---------------|---------------|---------|
 | Wallet daemon URL | `--wallet-daemon-url` | `networks.<active>.wallet-daemon-url` | `networks.<active>.wallet-daemon-url` | `http://127.0.0.1:5100/json_rpc` |
-| Metadata server URL | `--metadata-server-url` | `networks.<active>.metadata-server-url` | `networks.<active>.metadata-server-url` | esmeralda → `https://ootle-templates-esme.tari.com/`, localnet → `http://localhost:3000/`, others → none |
+| Metadata server URL | `--metadata-server-url` | `networks.<active>.metadata-server-url` | `networks.<active>.metadata-server-url` | esmeralda → `https://ootle.tari.com/community-templates`, localnet → `http://localhost:3000/`, others → none |
 | Template address | `--template-address` | `networks.<active>.template-address` | — | — |
 | Account | `--account` | `default-account` | `default-account` | Wallet daemon default |
 | Wallet daemon API key | `--api-key` | — (never stored in config) | — (never stored in config) | `TARI_WALLET_DAEMON_API_KEY` env var |

--- a/docs/03-reference/configuration-schema.md
+++ b/docs/03-reference/configuration-schema.md
@@ -55,7 +55,7 @@ folder = "wasm_templates"
 
 [networks.esmeralda]
 wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
-metadata-server-url = "https://ootle-templates-esme.tari.com/"
+metadata-server-url = "https://ootle.tari.com/community-templates"
 
 [networks.localnet]
 wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
@@ -84,7 +84,7 @@ metadata-server-url = "http://localhost:3000/"
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `wallet-daemon-url` | URL | `http://127.0.0.1:5100/json_rpc` | Wallet daemon JSON-RPC endpoint |
-| `metadata-server-url` | URL | esmeralda → `https://ootle-templates-esme.tari.com/`, localnet → `http://localhost:3000/`, others → none | Metadata server URL |
+| `metadata-server-url` | URL | esmeralda → `https://ootle.tari.com/community-templates`, localnet → `http://localhost:3000/`, others → none | Metadata server URL |
 
 ### CLI Overrides (`-e`)
 
@@ -122,7 +122,7 @@ default-network = "esmeralda"
 
 [networks.esmeralda]
 wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
-metadata-server-url = "https://ootle-templates-esme.tari.com/"
+metadata-server-url = "https://ootle.tari.com/community-templates"
 # template-address = "template_abc123..."  # written automatically by `tari publish`
 
 [networks.localnet]


### PR DESCRIPTION
## Summary

Sync the documentation with the actual code default for the esmeralda network's metadata server URL.

The code default in `crates/cli/src/project/config.rs:13` is:

```rust
pub const DEFAULT_METADATA_SERVER_URL_ESMERALDA: &str = "https://ootle.tari.com/community-templates";
```

…but the docs still referenced the old `https://ootle-templates-esme.tari.com/` value. This PR updates the four documentation files that mention it:

- `README.md`
- `docs/02-guides/project-configuration.md`
- `docs/03-reference/cli-commands.md`
- `docs/03-reference/configuration-schema.md`

Docs-only change; no code behavior is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)