### PR TITLE
ci: run PR checks on merge_group so the merge queue works

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -2,6 +2,7 @@ name: PR Check
 
 on:
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

The repo's `main` branch ruleset enables a **merge queue** (`SQUASH`, `ALLGREEN`) and requires the **`Test`** status check. However, `pr-check.yml` only triggered on `pull_request` and `workflow_dispatch`.

When a PR is added to the queue, GitHub creates a `gh-readonly-queue/main/...` branch and dispatches a **`merge_group`** event. With no workflow listening for that event, the required `Test` check never runs on the queue branch, so the queue entry sits in `AWAITING_CHECKS` until the 60-minute timeout — **nothing can merge through the queue**. (This is exactly what happened to #150, which had to be merged manually.)

## Fix

Add the `merge_group` trigger to `pr-check.yml`:

```yaml
on:
  pull_request:
  merge_group:
  workflow_dispatch:
```

Now the `Test` (and `file licenses`) jobs run on the queue branch, the queue sees the required check report green, and merges complete.

## ⚠️ This PR needs a one-time bypass merge

GitHub only fires `merge_group` for workflows that exist **on the default branch**. Since `main` doesn't yet contain this trigger, the queue still can't validate *this* PR — it will stall like the others. This PR must therefore be merged **once via admin/bypass** (org admins have `bypass_mode: always` on the ruleset). Every PR after this lands on `main` will merge through the queue normally.

Docs/CI-config only; no application code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)