### PR TITLE
feat(build): compile WASM templates with size-optimizing cargo profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5591,7 +5591,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tari-ootle-cli"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "cargo-generate",
@@ -5944,8 +5944,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_publish_lib"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
+ "curve25519-dalek",
  "hickory-proto",
  "ootle_serde",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/publish_lib", "crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.20.0"
+version = "0.20.1"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-cli"

--- a/crates/cli/src/cli/commands/build.rs
+++ b/crates/cli/src/cli/commands/build.rs
@@ -14,10 +14,15 @@ pub struct BuildArgs {
     /// Defaults to the current directory.
     #[arg(default_value = ".")]
     pub path: PathBuf,
+
+    /// Skip the size-optimizing release profile overrides passed to `cargo build`.
+    /// By default the template is compiled with size optimizations.
+    #[arg(long, default_value_t = false)]
+    pub no_cargo_opts: bool,
 }
 
 pub async fn handle(args: BuildArgs) -> anyhow::Result<()> {
-    let wasm_path = build_template(&args.path).await?;
+    let wasm_path = build_template(&args.path, !args.no_cargo_opts).await?;
     let size = tokio::fs::metadata(&wasm_path).await?.len() as usize;
 
     println!("✅ WASM binary: {} ({})", wasm_path.display(), util::human_bytes(size));

--- a/crates/cli/src/cli/commands/metadata/publish.rs
+++ b/crates/cli/src/cli/commands/metadata/publish.rs
@@ -115,7 +115,7 @@ pub async fn handle(
                     .default(true)
                     .interact()?;
                 if rebuild {
-                    crate::cli::commands::publish::build_template(&args.path).await?;
+                    crate::cli::commands::publish::build_template(&args.path, true).await?;
                     let new_cbor_path = find_metadata_cbor(&args.path).await?;
                     cbor_bytes = std::fs::read(&new_cbor_path).context("reading rebuilt metadata CBOR")?;
                     metadata = decode_metadata_cbor(&cbor_bytes)?;

--- a/crates/cli/src/cli/commands/publish.rs
+++ b/crates/cli/src/cli/commands/publish.rs
@@ -64,9 +64,26 @@ pub struct PublishArgs {
     /// Overrides the value in tari.config.toml and global CLI config.
     #[arg(long)]
     pub metadata_server_url: Option<url::Url>,
+
+    /// Skip the size-optimizing release profile overrides passed to `cargo build`.
+    /// By default the template is compiled with size optimizations (see `build_template`).
+    #[arg(long, default_value_t = false)]
+    pub no_cargo_opts: bool,
 }
 
-pub async fn build_template(crate_dir: &Path) -> anyhow::Result<PathBuf> {
+/// Size-optimizing `[profile.release]` overrides applied to the WASM build via `cargo build
+/// --config`. These are injected on the command line so a template's own `Cargo.toml` does not
+/// need to declare them, and (because `--config` takes precedence over the manifest) they are
+/// applied even when the template defines its own release profile.
+const CARGO_OPT_CONFIGS: &[&str] = &[
+    "profile.release.opt-level='s'",   // Optimize for size.
+    "profile.release.lto=true",        // Enable Link Time Optimization.
+    "profile.release.codegen-units=1", // Reduce number of codegen units to increase optimizations.
+    "profile.release.panic='abort'",   // Abort on panic.
+    "profile.release.strip=true",      // Strip symbols.
+];
+
+pub async fn build_template(crate_dir: &Path, optimize: bool) -> anyhow::Result<PathBuf> {
     let cargo_path = crate_dir.join("Cargo.toml");
     if !cargo_path.exists() {
         return Err(anyhow!("No Cargo.toml found at {}", cargo_path.display()));
@@ -80,7 +97,7 @@ pub async fn build_template(crate_dir: &Path) -> anyhow::Result<PathBuf> {
 
     let template_bin = loading!(
         format!("Building WASM template project **{}**", crate_name),
-        build_project(crate_dir, &crate_name).await
+        build_project(crate_dir, &crate_name, optimize).await
     )?;
 
     Ok(template_bin)
@@ -103,18 +120,22 @@ pub async fn handle(
         wallet_daemon_url: args.wallet_daemon_url,
         publish_metadata: args.publish_metadata,
         metadata_server_url: args.metadata_server_url,
+        no_cargo_opts: args.no_cargo_opts,
     };
     crate::cli::commands::template::publish::handle(config, network_override, api_key, template_args).await
 }
 
-async fn build_project(dir: &Path, name: &str) -> anyhow::Result<PathBuf> {
+async fn build_project(dir: &Path, name: &str, optimize: bool) -> anyhow::Result<PathBuf> {
     let mut cmd = Command::new("cargo");
-    cmd.arg("build")
-        .arg("--target=wasm32-unknown-unknown")
-        .arg("--release")
-        .current_dir(dir)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+    cmd.arg("build").arg("--target=wasm32-unknown-unknown").arg("--release");
+
+    if optimize {
+        for config in CARGO_OPT_CONFIGS {
+            cmd.arg("--config").arg(config);
+        }
+    }
+
+    cmd.current_dir(dir).stdout(Stdio::piped()).stderr(Stdio::piped());
 
     let process = cmd.spawn()?;
 

--- a/crates/cli/src/cli/commands/template/inspect_metadata.rs
+++ b/crates/cli/src/cli/commands/template/inspect_metadata.rs
@@ -64,7 +64,7 @@ pub async fn handle(args: InspectMetadataArgs) -> anyhow::Result<()> {
                         .default(true)
                         .interact()?;
                 if rebuild {
-                    build_template(&args.project_dir).await?;
+                    build_template(&args.project_dir, true).await?;
                     let new_cbor_path = find_metadata_cbor(&args.project_dir).await?;
                     cbor_bytes = std::fs::read(&new_cbor_path).context("reading rebuilt metadata CBOR")?;
                     metadata = decode_metadata_cbor(&cbor_bytes)?;

--- a/crates/cli/src/cli/commands/template/publish.rs
+++ b/crates/cli/src/cli/commands/template/publish.rs
@@ -65,6 +65,11 @@ pub struct TemplatePublishArgs {
     /// Overrides the value in tari.config.toml and global CLI config.
     #[arg(long)]
     pub metadata_server_url: Option<url::Url>,
+
+    /// Skip the size-optimizing release profile overrides passed to `cargo build`.
+    /// By default the template is compiled with size optimizations.
+    #[arg(long, default_value_t = false)]
+    pub no_cargo_opts: bool,
 }
 
 pub async fn handle(
@@ -101,7 +106,7 @@ pub async fn handle(
             println!("📦 Using provided WASM binary at {}", bin_path.display());
             bin_path
         },
-        None => build_template(crate_dir).await?,
+        None => build_template(crate_dir, !args.no_cargo_opts).await?,
     };
 
     // Find and read metadata CBOR from build output

--- a/crates/publish_lib/Cargo.toml
+++ b/crates/publish_lib/Cargo.toml
@@ -28,8 +28,13 @@ hickory-proto = "=0.26.1"
 tonic = { version = "0.12.3", features = ["tls"] }
 tempfile = "3.27.0"
 
+# Pin (transitive) curve25519-dalek: 5.0.0-rc.1 switched to the upstream `ff` 0.14 crate, which
+# breaks tari_bulletproofs_plus 0.5.0 (Scalar no longer exposes `pow_vartime`). Hold it at pre.6
+# until the crypto stack catches up. See https://github.com/tari-project/bulletproofs-plus/issues/148
+curve25519-dalek = "=5.0.0-pre.6"
+
 [package.metadata.cargo-machete]
-ignored = ["hickory-proto"]
+ignored = ["hickory-proto", "curve25519-dalek"]
 
 [features]
 wasm-opt = ["dep:wasm-opt", "tokio/fs"]


### PR DESCRIPTION
## Summary

Compile WASM templates with size-optimizing release profile settings, injected on the `cargo build` command line via `--config` so a template doesn't need to declare them in its own `Cargo.toml`. Because `--config` takes precedence over the manifest, the overrides apply even when a template defines its own `[profile.release]`:

```
opt-level = 's'      # Optimize for size
lto = true           # Link Time Optimization
codegen-units = 1    # More optimization
panic = 'abort'      # Abort on panic
strip = true         # Strip symbols
```

These are **on by default**. Pass `--no-cargo-opts` to `tari build` / `tari publish` (and `tari template publish`) to skip them and build with the template's plain release profile.

## Changes

- `build_project` / `build_template` take an `optimize` flag; the overrides live in a `CARGO_OPT_CONFIGS` const and are only added when enabled.
- `--no-cargo-opts` added to `tari build`, `tari publish`, and `tari template publish`.
- Internal "metadata stale → rebuild" paths (`inspect`, `metadata publish`) use the default opts so the cargo build cache stays consistent with a normal build.

## Dependency fix

Pins `curve25519-dalek` to `=5.0.0-pre.6`. `5.0.0-rc.1` switched to the upstream `ff` 0.14 crate, which breaks `tari_bulletproofs_plus` 0.5.0 (`Scalar` no longer exposes `pow_vartime`). Follows the repo's existing `hickory-proto` pinning idiom (direct dep + `cargo-machete` ignore). See tari-project/bulletproofs-plus#148.

## Testing

- `cargo check -p tari-ootle-cli --locked` compiles the whole workspace clean.
- Verified empirically that `cargo build --config "profile.release.opt-level='s'"` overrides a manifest's own `[profile.release]`, and that all five `--config` flags are accepted together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)