### PR TITLE
chore(deps): update tari ootle deps to latest crates.io versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
  "anyhow",
  "auth-git2",
  "cargo-util-schemas",
- "clap 4.6.1",
+ "clap",
  "console",
  "dialoguer",
  "env_logger",
@@ -840,17 +840,6 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
-]
-
-[[package]]
-name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "bitflags 1.3.2",
- "textwrap",
- "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1483,7 +1472,7 @@ version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0956799fa8678d4c50eed028f2de1c0552ae183c76e976cf7ca8c4e36a7c328"
 dependencies = [
- "clap 4.6.1",
+ "clap",
  "codespan-reporting",
  "indexmap 2.14.0",
  "proc-macro2",
@@ -1580,28 +1569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "dbus"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
-dependencies = [
- "libc",
- "libdbus-sys",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "dbus-secret-service"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
-dependencies = [
- "dbus",
- "zeroize",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3166,18 +3134,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
+name = "keyring-core"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
- "byteorder",
- "dbus-secret-service",
  "log",
- "security-framework 2.11.1",
- "security-framework 3.7.0",
- "windows-sys 0.60.2",
- "zeroize",
 ]
 
 [[package]]
@@ -3251,15 +3213,6 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "libdbus-sys"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
-dependencies = [
- "pkg-config",
-]
 
 [[package]]
 name = "libgit2-sys"
@@ -3830,9 +3783,9 @@ dependencies = [
 
 [[package]]
 name = "ootle_byte_type"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ed5152cd8bb0d86a177840f52370be19f01dad9dc671bb584b7091f3aa0e2a"
+checksum = "0548d6db83566dc083ce0227f5b2518f8e7a34b92bedbbc667ae0ac8f0f96e03"
 dependencies = [
  "tari_crypto",
  "tari_template_lib_types",
@@ -4202,30 +4155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit 0.25.12+spec-1.1.0",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -4914,7 +4843,7 @@ dependencies = [
  "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -4951,7 +4880,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -5034,19 +4963,6 @@ name = "scratch"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
 
 [[package]]
 name = "security-framework"
@@ -5445,30 +5361,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "strum"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5602,12 +5494,12 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tari-ootle-cli"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "cargo-generate",
  "cargo_toml 1.0.0",
- "clap 4.6.1",
+ "clap",
  "convert_case 0.11.0",
  "dialoguer",
  "dirs-next 2.0.0",
@@ -5634,9 +5526,9 @@ dependencies = [
 
 [[package]]
 name = "tari_bor"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8724c7349ef374526ae1e9cb3944a98a6af8c1c4b30f5d3581d777f8a96a7a"
+checksum = "bdabc3ab961b415b5bc600b644b8b4c05d8934a52c0b4fe51cb9202844e7b7a7"
 dependencies = [
  "borsh",
  "indexmap 2.14.0",
@@ -5668,9 +5560,9 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "5.3.1"
+version = "5.4.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fdd7804e44f51c2f8ae438ccc2805aeef0842ce8120f856f47f5b982e6652ca"
+checksum = "03dceaafea43bf5f39d0771337a485d2db33f99ede865b98278c0426d919db74"
 dependencies = [
  "anyhow",
  "cargo_toml 0.20.5",
@@ -5684,7 +5576,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
- "structopt",
  "tari_features",
  "tempfile",
  "thiserror 2.0.18",
@@ -5692,9 +5583,9 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "5.3.1"
+version = "5.4.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a5ea88eaac18365959193142a7699b48ddb67cdcfc6e809fbc87fd2423f8a79"
+checksum = "55476767f8f53cc3bca684b22e2184962bab59923df66ba8d15d28dc6223ea79"
 dependencies = [
  "argon2 0.6.0-rc.8",
  "base64 0.22.1",
@@ -5730,9 +5621,9 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.32.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "140594c63ad1e72e49d3252e23f14fb873a7560d8c581e3de6d55e93251726bb"
+checksum = "5d061aeefebfd14575601e4d94de3103398d0f6f1c49675eb7e65dab3b264cd6"
 dependencies = [
  "borsh",
  "minicbor",
@@ -5772,9 +5663,9 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.32.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c63f8fa1368a28c93f1f0a7afdb69e9c9a8df8838627cf09db7290dcf032552"
+checksum = "c77463b105eda6f1f6f7f54ed028df8397e2bbc79413e03481e1d99d2f8d15a5"
 dependencies = [
  "blake2 0.10.6",
  "indexmap 2.14.0",
@@ -5799,9 +5690,9 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.32.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca43de693d8707c34ab6f1217ecb50dc05706c7a307093fc1cf3921c96a78fc"
+checksum = "01a65452fce0cb1d73bf1ec2e290b9a0c8b659e9181f46c056c145498b166f90"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -5818,6 +5709,7 @@ dependencies = [
  "rand 0.10.1",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tari_bor",
  "tari_crypto",
  "tari_hashing",
@@ -5829,15 +5721,15 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "5.3.1"
+version = "5.4.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb0c46e65c7731d8a8ddf07ca9f9b9f7833fac40bb16cff864ef7d06f2b9634"
+checksum = "1e50c4283a96798248b98875baf71c530b1d802644cb4ec7a4b933b99ffed69e"
 
 [[package]]
 name = "tari_hashing"
-version = "5.3.1"
+version = "5.4.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3bb7a220ed807019f4455177dc7d523477c22b666ef2c7c63791305fadda728"
+checksum = "5cab6b508c741d26d1dc904cd8e01430dc705fe349e07184a552d3ffa4a020e2"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -5847,9 +5739,9 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f90e7621c8c5ed437b66979c4334c1e0cc223e0574dceb3564b0fca586b2de"
+checksum = "cc4fdc0f3b9d5f20b4b83ce955e105414a7416a684c84316b6a5398457209457"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -5871,9 +5763,9 @@ dependencies = [
 
 [[package]]
 name = "tari_jellyfish"
-version = "5.3.1"
+version = "5.4.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f81a3e556437e19872b57eee30c740880b3621a4c957cc110a7f67aa73054b9"
+checksum = "ba442a0cca29e6bf7becc95f63d1ae7cd846ac2f7649fa65fefb86e4c58f6b72"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -5886,9 +5778,9 @@ dependencies = [
 
 [[package]]
 name = "tari_max_size"
-version = "5.3.1"
+version = "5.4.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "289b2e2524a8e5f889d9a861a6df222c391921f2ba568101e87a80ec91fe8d97"
+checksum = "05ca6cccb9b80dbf75b86e131e75949404854a0f53f9f3936760b71ab7f1a7b3"
 dependencies = [
  "borsh",
  "serde",
@@ -5910,9 +5802,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_address"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be93a3494f07bd590a818bb9e057520bb9ca095291098b7587cb01c1973365be"
+checksum = "d4f97fb39c2e35a4f85e5ea0ade75c70ab9a1d1d1c8a2e37c45f7f20946839e4"
 dependencies = [
  "bech32",
  "ootle-network",
@@ -5925,9 +5817,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.32.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ae3b89f3f22222cbf41dc61eb0c2ac39dc1baca990f43264241b2b3c3dd5bc"
+checksum = "7e930e18f5b19a4b3876cb310313306ebfb94d14ea546074802dcec76294987c"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -5955,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_publish_lib"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "curve25519-dalek",
  "hickory-proto",
@@ -5979,9 +5871,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_metadata"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2869db740d797c733974cf8a098decceae256efce0f37aee3343445d5092015"
+checksum = "096675171d462ef7feee491540ac347af87b8ce3c54fe7d9be30116075b792ea"
 dependencies = [
  "borsh",
  "cargo_toml 0.22.3",
@@ -6000,9 +5892,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.32.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9603d7cca38c811c51e832969a1e493cc73e1d70bb9f5d2cd3bc651da62cae0"
+checksum = "a1d243eec3bd6fe844200798e9ffff7e7654111ae1892a0a4d699e85948de601"
 dependencies = [
  "borsh",
  "hex",
@@ -6026,9 +5918,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.32.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77265be1b2d96be3b644c596e6e61d974e7805f3e124b62ad48ae872728d7a8e"
+checksum = "709add29f6bb1dc78b3250bf72216e61f7ee05ea11cb383b228e4a95c3bc1af5"
 dependencies = [
  "argon2 0.5.3",
  "blake2 0.10.6",
@@ -6054,13 +5946,13 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_sdk"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69c70984b0e6188273a8bc5e2d580bfac299703c25d2d4ec1661f03c8ac7cc29"
+checksum = "d955987c84c07bd05fddb835ba2ac433c08d2bd35d8d6895d94c535f53fd9de1"
 dependencies = [
  "anyhow",
  "futures",
- "keyring",
+ "keyring-core",
  "log",
  "ootle-network",
  "ootle_byte_type",
@@ -6090,9 +5982,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_walletd_client"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffb7fc0f5d5650e85262f3ed9e380fb8025dff57bb402bbcf8244b03a26eb85"
+checksum = "fb714262d1bfb4ca1d6e864663887f5a0ef3b3a9b0bfd5fc17904286c6d7fe0b"
 dependencies = [
  "hex",
  "ootle_serde",
@@ -6116,9 +6008,9 @@ dependencies = [
 
 [[package]]
 name = "tari_sidechain"
-version = "5.3.1"
+version = "5.4.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c719acd1516056073124688c01370674ddb8d6275218bfbb944b0ee439b9cae"
+checksum = "801b65b9d7f71c039e89fe53df6a8ca4c2bbd041ab2cc6d65b69012c5e95b640"
 dependencies = [
  "borsh",
  "hex",
@@ -6134,9 +6026,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_abi"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f191f916d35dfcc08fda805c397291fafc14dbc032e2f2f5c20b0a76eda22c7"
+checksum = "2c49d04c42c5dc5c297573953f2767a0e12a41893ab78ea1a1fb30329629dc11"
 dependencies = [
  "minicbor",
  "serde",
@@ -6146,9 +6038,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.32.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3ea94593eb371bed225c4ea1a0f406307bb09496f34dcb2bfa5a4aa0d42943c"
+checksum = "e7c5f56e8bde8a20f098614a8f2d7c60b7bfb0fe30034b4c141a56a810128121"
 dependencies = [
  "anyhow",
  "tari_template_lib_types",
@@ -6156,9 +6048,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229d384ec06be2c3cb20b118b026dca89f9e145f4379c99081f8ecded34e6104"
+checksum = "a1e64b7c2d3cfdae2e1eb49525e77ebdd957f6cbfc9a27ac29f50c439c6f23a8"
 dependencies = [
  "borsh",
  "minicbor",
@@ -6171,9 +6063,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib_types"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351ed3d15215e9878a0113746b6e391a41ab35976764f9a104aa25364b56115c"
+checksum = "1b2b8da56d82f520e139ba7f0f640657f5ddfa1e2aa852dd8d34c9a62b7f9d5c"
 dependencies = [
  "bnum",
  "borsh",
@@ -6186,9 +6078,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479aabf617eccc8388a8d3461b3b65dc8996d22ea27372fd1d5530a6b0fff2d1"
+checksum = "e7f2f8515b23f59706f636186d67c89e1efe678eea4921300a9eaf884e96e258"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6270,15 +6162,6 @@ checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width 0.1.14",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/publish_lib", "crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.20.1"
+version = "0.20.2"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-cli"
@@ -12,13 +12,13 @@ license = "BSD-3-Clause"
 [workspace.dependencies]
 tari_ootle_publish_lib = { path = "crates/publish_lib", version = "0.20" }
 
-tari_ootle_walletd_client = "0.32"
-tari_engine = "0.32"
-tari_engine_types = "0.32"
-tari_ootle_common_types = "0.32"
-tari_template_lib_types = "0.27"
-tari_ootle_template_metadata = "0.7"
-tari_ootle_wallet_sdk = "0.32"
+tari_ootle_walletd_client = "0.34"
+tari_engine = "0.35"
+tari_engine_types = "0.35"
+tari_ootle_common_types = "0.35"
+tari_template_lib_types = "0.28"
+tari_ootle_template_metadata = "0.8"
+tari_ootle_wallet_sdk = "0.34"
 tari_utilities = "0.10"
 ootle-network = "0.2"
 ootle_serde = "0.3"


### PR DESCRIPTION
## Summary

Updates the Tari Ootle workspace dependencies to their latest published versions on crates.io.

| Crate | Before | After |
|---|---|---|
| `tari_ootle_walletd_client` | 0.32 | 0.34 |
| `tari_ootle_wallet_sdk` | 0.32 | 0.34 |
| `tari_engine` | 0.32 | 0.35 |
| `tari_engine_types` | 0.32 | 0.35 |
| `tari_ootle_common_types` | 0.32 | 0.35 |
| `tari_template_lib_types` | 0.27 | 0.28 |
| `tari_ootle_template_metadata` | 0.7 | 0.8 |

`tari_utilities` (0.10), `ootle-network` (0.2), and `ootle_serde` (0.3) were already at their latest.

## Notes

- The `walletd_client`/`wallet_sdk` crates are versioned at 0.34 but depend on the `^0.35` engine ecosystem — the mixed version numbers are intentional and consistent.
- Bumped the transitive `tari_bor` to 0.14.2: `tari_template_lib_types 0.28.0` declares `tari_bor ^0.14` but uses symbols (`MAX_DECODE_DEPTH`, `decode_with_fn`) only present in a 0.14 patch release; the lock had pinned 0.14.0.
- Bumped the workspace version `0.20.1` → `0.20.2`.
- No source code changes were required — the API surface the CLI uses is unchanged across these versions.

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` — all 18 tests pass
- [x] `cargo clippy --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)