### PR TITLE
feat: pin new templates to the latest tari_ootle_template_build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5591,7 +5591,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tari-ootle-cli"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "cargo-generate",
@@ -5945,7 +5945,7 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_publish_lib"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "hickory-proto",
  "ootle_serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@ members = ["crates/publish_lib", "crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.23.0"
+version = "0.24.0"
 edition = "2024"
 authors = ["The Tari Development Community"]
 repository = "https://github.com/tari-project/tari-cli"
 license = "BSD-3-Clause"
 
 [workspace.dependencies]
-tari_ootle_publish_lib = { path = "crates/publish_lib", version = "0.23" }
+tari_ootle_publish_lib = { path = "crates/publish_lib", version = "0.24" }
 
 tari_ootle_walletd_client = "0.40"
 tari_engine = "0.39"

--- a/crates/cli/src/cli/commands/template/init_metadata.rs
+++ b/crates/cli/src/cli/commands/template/init_metadata.rs
@@ -8,8 +8,12 @@ use clap::Parser;
 use dialoguer::Input;
 use tokio::fs;
 
+use crate::cli::crates_io;
+
 const BUILD_DEP_KEY: &str = "tari_ootle_template_build";
-const BUILD_DEP_VERSION: &str = "0.7";
+/// Used when crates.io cannot be reached. It only needs to be new enough to work, not current —
+/// [`resolve_build_dep_version`] looks up the latest release when it can.
+const FALLBACK_BUILD_DEP_VERSION: &str = "0.7";
 const BUILD_RS_CONTENT: &str = r#"fn main() {
     tari_ootle_template_build::TemplateMetadataBuilder::new()
         .build()
@@ -71,7 +75,7 @@ pub async fn handle(args: InitMetadataArgs) -> anyhow::Result<()> {
         .context("reading Cargo.toml")?;
 
     let metadata = resolve_metadata(&args, &cargo_toml_content)?;
-    let updated = add_build_dependency(&cargo_toml_content)?;
+    let updated = add_latest_build_dependency(&cargo_toml_content).await?;
     let updated = add_template_metadata(&updated, &metadata)?;
 
     fs::write(&cargo_toml_path, &updated)
@@ -232,7 +236,46 @@ fn normalize_supersedes(s: Option<&str>) -> Option<String> {
     s.map(str::trim).filter(|s| !s.is_empty()).map(str::to_string)
 }
 
-fn add_build_dependency(cargo_toml_content: &str) -> anyhow::Result<String> {
+/// Add the metadata build dependency, pinned to the latest release on crates.io. An existing
+/// declaration is left exactly as the user wrote it.
+async fn add_latest_build_dependency(cargo_toml_content: &str) -> anyhow::Result<String> {
+    if declares_build_dependency(cargo_toml_content)? {
+        println!("ℹ️  {BUILD_DEP_KEY} already in [build-dependencies], skipping");
+        return Ok(cargo_toml_content.to_string());
+    }
+
+    let version = resolve_build_dep_version().await;
+    let updated = add_build_dependency(cargo_toml_content, &version)?;
+    println!("✅ Added {BUILD_DEP_KEY} = \"{version}\" to [build-dependencies]");
+    Ok(updated)
+}
+
+/// The version requirement to write for the build dependency. Falling back to a known-good version
+/// keeps `tari init` working offline or behind a firewall.
+async fn resolve_build_dep_version() -> String {
+    match crates_io::latest_version_req(BUILD_DEP_KEY).await {
+        Ok(version) => version,
+        Err(error) => {
+            println!(
+                "ℹ️  Could not check crates.io for the latest {BUILD_DEP_KEY} ({error:#}), \
+                 using {FALLBACK_BUILD_DEP_VERSION}"
+            );
+            FALLBACK_BUILD_DEP_VERSION.to_string()
+        },
+    }
+}
+
+fn declares_build_dependency(cargo_toml_content: &str) -> anyhow::Result<bool> {
+    let doc = cargo_toml_content
+        .parse::<toml_edit::DocumentMut>()
+        .context("parsing Cargo.toml")?;
+    Ok(doc
+        .get("build-dependencies")
+        .and_then(|deps| deps.get(BUILD_DEP_KEY))
+        .is_some())
+}
+
+fn add_build_dependency(cargo_toml_content: &str, version: &str) -> anyhow::Result<String> {
     let mut doc = cargo_toml_content
         .parse::<toml_edit::DocumentMut>()
         .context("parsing Cargo.toml")?;
@@ -244,11 +287,7 @@ fn add_build_dependency(cargo_toml_content: &str) -> anyhow::Result<String> {
         .as_table_mut()
         .ok_or_else(|| anyhow!("[build-dependencies] is not a table"))?;
 
-    if build_deps.contains_key(BUILD_DEP_KEY) {
-        println!("ℹ️  {BUILD_DEP_KEY} already in [build-dependencies], skipping");
-    } else {
-        build_deps.insert(BUILD_DEP_KEY, toml_edit::value(BUILD_DEP_VERSION));
-    }
+    build_deps.insert(BUILD_DEP_KEY, toml_edit::value(version));
 
     Ok(doc.to_string())
 }
@@ -338,7 +377,7 @@ pub async fn auto_init(crate_dir: &Path) -> anyhow::Result<()> {
         supersedes: None,
     };
 
-    let updated = add_build_dependency(&content)?;
+    let updated = add_latest_build_dependency(&content).await?;
     let updated = add_template_metadata(&updated, &empty_metadata)?;
     fs::write(&cargo_toml_path, &updated)
         .await
@@ -391,13 +430,15 @@ version = "0.1.0"
 [dependencies]
 foo = "1.0"
 "#;
-        let result = add_build_dependency(input).unwrap();
+        let result = add_build_dependency(input, "0.11").unwrap();
         assert!(result.contains("[build-dependencies]"));
-        assert!(result.contains("tari_ootle_template_build"));
+        assert!(result.contains("tari_ootle_template_build = \"0.11\""));
     }
 
-    #[test]
-    fn idempotent_build_dependency() {
+    #[tokio::test]
+    async fn existing_build_dependency_is_left_alone() {
+        // Never silently re-pin a version the user chose deliberately — and never hit the network
+        // to decide that.
         let input = r#"[package]
 name = "my-template"
 version = "0.1.0"
@@ -405,8 +446,23 @@ version = "0.1.0"
 [build-dependencies]
 tari_ootle_template_build = "0.3"
 "#;
-        let result = add_build_dependency(input).unwrap();
+        let result = add_latest_build_dependency(input).await.unwrap();
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn detects_an_existing_build_dependency() {
+        assert!(declares_build_dependency("[build-dependencies]\ntari_ootle_template_build = \"0.3\"\n").unwrap());
+        assert!(!declares_build_dependency("[build-dependencies]\nfoo = \"1\"\n").unwrap());
+        assert!(!declares_build_dependency("[package]\nname = \"t\"\n").unwrap());
+    }
+
+    #[test]
+    fn build_dependency_version_is_overwritten_when_given() {
+        let input = "[build-dependencies]\ntari_ootle_template_build = \"0.3\"\n";
+        let result = add_build_dependency(input, "0.11").unwrap();
         assert_eq!(result.matches("tari_ootle_template_build").count(), 1);
+        assert!(result.contains("\"0.11\""));
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/template/init_metadata.rs
+++ b/crates/cli/src/cli/commands/template/init_metadata.rs
@@ -11,9 +11,10 @@ use tokio::fs;
 use crate::cli::crates_io;
 
 const BUILD_DEP_KEY: &str = "tari_ootle_template_build";
-/// Used when crates.io cannot be reached. It only needs to be new enough to work, not current —
-/// [`resolve_build_dep_version`] looks up the latest release when it can.
-const FALLBACK_BUILD_DEP_VERSION: &str = "0.7";
+/// Used when crates.io cannot be reached. Keep this at the latest release when cutting a CLI
+/// release: an offline `tari init` should still scaffold a current template, not an old one.
+/// [`resolve_build_dep_version`] prefers whatever crates.io reports when it can reach it.
+const FALLBACK_BUILD_DEP_VERSION: &str = "0.11";
 const BUILD_RS_CONTENT: &str = r#"fn main() {
     tari_ootle_template_build::TemplateMetadataBuilder::new()
         .build()

--- a/crates/cli/src/cli/crates_io.rs
+++ b/crates/cli/src/cli/crates_io.rs
@@ -1,0 +1,152 @@
+// Copyright 2024 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! Minimal crates.io lookups, so the CLI can write a current version requirement into a
+//! template's manifest instead of a hardcoded one that silently goes stale.
+//!
+//! Uses the [sparse index] rather than the crates.io API: it needs no authentication, has no
+//! User-Agent policy, and returns one compact JSON line per published version.
+//!
+//! [sparse index]: https://doc.rust-lang.org/cargo/reference/registry-index.html
+
+use std::time::Duration;
+
+use anyhow::{Context, anyhow};
+
+const SPARSE_INDEX_URL: &str = "https://index.crates.io";
+
+/// Kept short: every caller has a usable fallback, so waiting is worse than giving up.
+const LOOKUP_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// The latest stable version of `crate_name` as a `major.minor` requirement (e.g. `"0.11"`),
+/// which is what a Cargo dependency conventionally pins.
+///
+/// Yanked and pre-release versions are ignored.
+pub async fn latest_version_req(crate_name: &str) -> anyhow::Result<String> {
+    let url = format!("{SPARSE_INDEX_URL}/{}", index_path(crate_name));
+    let response = reqwest::Client::builder()
+        .timeout(LOOKUP_TIMEOUT)
+        .build()?
+        .get(&url)
+        .send()
+        .await
+        .with_context(|| format!("querying {url}"))?;
+
+    if !response.status().is_success() {
+        return Err(anyhow!("{url} returned {}", response.status()));
+    }
+
+    let body = response.text().await.context("reading crates.io index response")?;
+    let version =
+        latest_stable_version(&body).ok_or_else(|| anyhow!("no stable versions of {crate_name} found on crates.io"))?;
+
+    Ok(format!("{}.{}", version.0, version.1))
+}
+
+/// The crates.io index shards by name length: 1 and 2 character names live under `1/` and `2/`,
+/// 3 character names under `3/{first char}/`, and everything else under `{ab}/{cd}/`.
+fn index_path(crate_name: &str) -> String {
+    let name = crate_name.to_lowercase();
+    match name.len() {
+        0 => name,
+        1 => format!("1/{name}"),
+        2 => format!("2/{name}"),
+        3 => format!("3/{}/{name}", &name[0..1]),
+        _ => format!("{}/{}/{name}", &name[0..2], &name[2..4]),
+    }
+}
+
+/// Highest non-yanked, non-prerelease version in a sparse index response (one JSON object per
+/// line). Lines are ordered by publication, not by version, so they are compared numerically.
+fn latest_stable_version(body: &str) -> Option<(u64, u64, u64)> {
+    body.lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter(|entry| entry["yanked"].as_bool() != Some(true))
+        .filter_map(|entry| parse_stable_version(entry["vers"].as_str()?))
+        .max()
+}
+
+/// `1.2.3` -> `(1, 2, 3)`. Pre-release and build-metadata versions are rejected: a template should
+/// not be pinned to one by default.
+fn parse_stable_version(vers: &str) -> Option<(u64, u64, u64)> {
+    if vers.contains(['-', '+']) {
+        return None;
+    }
+    let mut parts = vers.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next().unwrap_or("0").parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((major, minor, patch))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn index_paths_shard_by_name_length() {
+        assert_eq!(index_path("a"), "1/a");
+        assert_eq!(index_path("ab"), "2/ab");
+        assert_eq!(index_path("abc"), "3/a/abc");
+        assert_eq!(
+            index_path("tari_ootle_template_build"),
+            "ta/ri/tari_ootle_template_build"
+        );
+    }
+
+    #[test]
+    fn index_paths_are_lowercased() {
+        assert_eq!(index_path("Inflector"), "in/fl/inflector");
+    }
+
+    #[test]
+    fn picks_the_highest_version_not_the_last_line() {
+        // A patch release of an older line is published after a newer minor.
+        let body = concat!(
+            r#"{"name":"c","vers":"0.9.0","yanked":false}"#,
+            "\n",
+            r#"{"name":"c","vers":"0.11.0","yanked":false}"#,
+            "\n",
+            r#"{"name":"c","vers":"0.9.1","yanked":false}"#,
+            "\n",
+        );
+        assert_eq!(latest_stable_version(body), Some((0, 11, 0)));
+    }
+
+    #[test]
+    fn skips_yanked_and_prerelease_versions() {
+        let body = concat!(
+            r#"{"name":"c","vers":"0.7.0","yanked":false}"#,
+            "\n",
+            r#"{"name":"c","vers":"0.8.0","yanked":true}"#,
+            "\n",
+            r#"{"name":"c","vers":"0.9.0-rc.1","yanked":false}"#,
+            "\n",
+        );
+        assert_eq!(latest_stable_version(body), Some((0, 7, 0)));
+    }
+
+    #[test]
+    fn ignores_unparseable_lines() {
+        let body = concat!("not json\n", r#"{"name":"c","vers":"1.2.3","yanked":false}"#, "\n");
+        assert_eq!(latest_stable_version(body), Some((1, 2, 3)));
+    }
+
+    #[test]
+    fn no_stable_versions_yields_none() {
+        let body = concat!(r#"{"name":"c","vers":"0.1.0","yanked":true}"#, "\n");
+        assert_eq!(latest_stable_version(body), None);
+    }
+
+    #[test]
+    fn version_parsing_rejects_junk() {
+        assert_eq!(parse_stable_version("1.2.3"), Some((1, 2, 3)));
+        assert_eq!(parse_stable_version("1.2"), Some((1, 2, 0)));
+        assert_eq!(parse_stable_version("1.2.3.4"), None);
+        assert_eq!(parse_stable_version("1.2.3-beta"), None);
+        assert_eq!(parse_stable_version("nope"), None);
+    }
+}

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -4,5 +4,6 @@
 pub mod command;
 pub mod commands;
 pub mod config;
+pub mod crates_io;
 pub mod macros;
 pub mod util;

--- a/docs/03-reference/cli-commands.md
+++ b/docs/03-reference/cli-commands.md
@@ -284,6 +284,8 @@ tari template init [OPTIONS] [PATH]
 
 Adds `tari_ootle_template_build` to `[build-dependencies]`, creates `build.rs`, and writes a `[package.metadata.tari-template]` section to `Cargo.toml`.
 
+The build dependency is pinned to the latest release found on the crates.io index. If crates.io cannot be reached the CLI says so and falls back to a known-good version, so `tari template init` still works offline. An existing `tari_ootle_template_build` declaration is never re-pinned.
+
 ### `template inspect`
 
 Inspects a template metadata CBOR file. Alias: `template inspect-metadata`.

--- a/docs/03-reference/cli-commands.md
+++ b/docs/03-reference/cli-commands.md
@@ -284,7 +284,7 @@ tari template init [OPTIONS] [PATH]
 
 Adds `tari_ootle_template_build` to `[build-dependencies]`, creates `build.rs`, and writes a `[package.metadata.tari-template]` section to `Cargo.toml`.
 
-The build dependency is pinned to the latest release found on the crates.io index. If crates.io cannot be reached the CLI says so and falls back to a known-good version, so `tari template init` still works offline. An existing `tari_ootle_template_build` declaration is never re-pinned.
+The build dependency is pinned to the latest release found on the crates.io index. If crates.io cannot be reached the CLI says so and falls back to the latest version known at CLI release time, so `tari template init` still works offline. An existing `tari_ootle_template_build` declaration is never re-pinned.
 
 ### `template inspect`
 


### PR DESCRIPTION
`tari init` / `tari template init` wrote a hardcoded `tari_ootle_template_build = "0.7"` into every scaffolded template. crates.io is on **0.11**, so new templates were pinned four minor versions behind on day one, and nothing about the release process would ever catch it.

## Approach

Look the version up on the [crates.io sparse index](https://index.crates.io) rather than the API — no auth, no User-Agent policy, one compact JSON line per published release. Take the highest non-yanked, non-prerelease version and write it as a `major.minor` requirement.

New module `crates/cli/src/cli/crates_io.rs`, ~150 lines including tests. `reqwest` was already a dependency (rustls + json), so no new deps.

## Behaviour

- **Already declared?** No lookup at all — a version the user chose deliberately is never re-pinned.
- **Offline / firewalled / slow?** 3s timeout, then a message saying why, then the previously hardcoded `0.7` as a fallback. `tari init` keeps working without network access.
- Index sharding (`1/`, `2/`, `3/{c}/`, `{ab}/{cd}/`) and name lowercasing are handled per the registry spec.

```
$ tari template init -y
✅ Added tari_ootle_template_build = "0.11" to [build-dependencies]

$ tari template init -y          # second run
ℹ️  tari_ootle_template_build already in [build-dependencies], skipping

$ HTTPS_PROXY=http://127.0.0.1:9 tari template init -y      # no network
ℹ️  Could not check crates.io for the latest tari_ootle_template_build (…Connection refused…), using 0.7
✅ Added tari_ootle_template_build = "0.7" to [build-dependencies]
```

## Note on the other hardcoded 0.7

`publish.rs:239` also mentions `^0.7`, but that one is a **compatibility floor** — pre-0.7 emitted map-encoded CBOR — not a "latest", so it is deliberately left alone.

The fallback constant does not disappear; it just stops being the source of truth, so letting it age is no longer silently harmful.

## Testing

10 new unit tests covering index sharding, lowercasing, picking the highest version rather than the last line published, and skipping yanked/prerelease/malformed entries — all pure, no network. `add_build_dependency` is now a pure function taking the version, so the existing tests stay offline too. `cargo test -p tari-ootle-cli`: 54 passed. Clippy and fmt clean. Manually exercised the online, already-declared, and offline paths shown above.

Version bumped to 0.24.0.

